### PR TITLE
Use base URL for Ktor client

### DIFF
--- a/src/commonMain/kotlin/com/xebia/functional/ktor.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/ktor.kt
@@ -1,22 +1,17 @@
 package com.xebia.functional
 
-import arrow.core.Either
-import arrow.core.nonFatalOrThrow
 import arrow.fx.coroutines.ResourceScope
-import arrow.resilience.Schedule
-import arrow.resilience.ScheduleStep
-import com.xebia.functional.env.RetryConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.Url
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
-import kotlin.time.Duration
 
 inline fun <reified A> HttpRequestBuilder.configure(token: String, request: A): Unit {
   header("Authorization", "Bearer $token")
@@ -24,9 +19,12 @@ inline fun <reified A> HttpRequestBuilder.configure(token: String, request: A): 
   setBody(request)
 }
 
-suspend fun ResourceScope.httpClient(engine: HttpClientEngine): HttpClient =
+suspend fun ResourceScope.httpClient(engine: HttpClientEngine, baseUrl: Url): HttpClient =
   install({
     HttpClient(engine) {
       install(ContentNegotiation) { json() }
+      defaultRequest {
+        url(baseUrl.toString())
+      }
     }
   }) { client, _ -> client.close() }

--- a/src/commonMain/kotlin/com/xebia/functional/llm/huggingface/HuggingFaceClient.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/llm/huggingface/HuggingFaceClient.kt
@@ -7,16 +7,8 @@ import com.xebia.functional.httpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.header
 import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.client.request.url
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
 import io.ktor.http.path
-import io.ktor.serialization.kotlinx.json.json
 
 interface HuggingFaceClient {
   suspend fun generate(request: InferenceRequest, model: Model): List<Generation>
@@ -25,7 +17,7 @@ interface HuggingFaceClient {
 suspend fun ResourceScope.KtorHuggingFaceClient(
   engine: HttpClientEngine,
   config: HuggingFaceConfig
-): HuggingFaceClient = KtorHuggingFaceClient(httpClient(engine), config)
+): HuggingFaceClient = KtorHuggingFaceClient(httpClient(engine, config.baseUrl), config)
 
 private class KtorHuggingFaceClient(
   private val httpClient: HttpClient,
@@ -33,7 +25,7 @@ private class KtorHuggingFaceClient(
 ) : HuggingFaceClient {
 
   override suspend fun generate(request: InferenceRequest, model: Model): List<Generation> {
-    val response = httpClient.post(config.baseUrl) {
+    val response = httpClient.post {
       url { path("models", model.name) }
       configure(config.token, request)
     }

--- a/src/commonMain/kotlin/com/xebia/functional/llm/openai/OpenAIClient.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/llm/openai/OpenAIClient.kt
@@ -9,6 +9,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.request.post
+import io.ktor.http.path
 
 interface OpenAIClient {
   suspend fun createCompletion(request: CompletionRequest): List<CompletionChoice>
@@ -18,25 +19,29 @@ interface OpenAIClient {
 suspend fun ResourceScope.KtorOpenAIClient(
   engine: HttpClientEngine,
   config: OpenAIConfig
-): OpenAIClient = KtorOpenAIClient(httpClient(engine), config)
+): OpenAIClient = KtorOpenAIClient(httpClient(engine, config.baseUrl), config)
 
 private class KtorOpenAIClient(
   private val httpClient: HttpClient,
   private val config: OpenAIConfig
 ) : OpenAIClient {
 
-  private val baseUrl = "https://api.openai.com/v1"
-
   override suspend fun createCompletion(request: CompletionRequest): List<CompletionChoice> {
     val response = config.retryConfig.schedule().retry {
-      httpClient.post("$baseUrl/completions") { configure(config.token, request) }
+      httpClient.post {
+        url { path("completions") }
+        configure(config.token, request)
+      }
     }
     return response.body()
   }
 
   override suspend fun createEmbeddings(request: EmbeddingRequest): EmbeddingResult {
     val response = config.retryConfig.schedule().retry {
-      httpClient.post("$baseUrl/embeddings") { configure(config.token, request) }
+      httpClient.post {
+        url { path("embeddings") }
+        configure(config.token, request)
+      }
     }
     return response.body()
   }


### PR DESCRIPTION
This pull request adds the OpenAI API base URL to the config class. Additionally, it proposes using the `defaultRequest` builder for the Ktor client to specify the base URL, so we only need to set the specific path for the endpoint to which we want to send the request.