### PR TITLE
Set up common repositories for subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,6 @@ import org.jetbrains.dokka.gradle.DokkaTask
 
 version = "0.0.1-SNAPSHOT"
 
-repositories {
-  mavenCentral()
-}
-
 plugins {
   base
   alias(libs.plugins.kotlin.multiplatform)

--- a/scala/build.gradle.kts
+++ b/scala/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
     alias(libs.plugins.scala.multiversion)
 }
 
-repositories {
-    mavenCentral()
-    maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
-}
-
 dependencies {
     implementation(libs.ciris.core)
     implementation(libs.ciris.refined)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,18 @@
+dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
+    repositories {
+        mavenCentral()
+        maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
     }
-    
 }
+
 rootProject.name = "langchain4k"
 include("nodejs-commandexecutor")
 include("example")


### PR DESCRIPTION
This pull request centralizes the declaration of the common repositories in the `settings.gradle.kts` file using the `dependencyResolutionManagement` block. Check it out in the [Gradle documentation](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:centralized-repository-declaration)