### PR TITLE
refactor: remove duplicate Document model

### DIFF
--- a/src/commonMain/kotlin/com/xebia/functional/domain/Document.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/domain/Document.kt
@@ -1,3 +1,0 @@
-package com.xebia.functional.domain
-
-data class Document(val content: String)

--- a/src/commonMain/kotlin/com/xebia/functional/loaders/BaseLoader.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/loaders/BaseLoader.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.loaders
 
-import com.xebia.functional.domain.Document
+import com.xebia.functional.Document
 import com.xebia.functional.textsplitters.BaseTextSplitter
 
 interface BaseLoader {

--- a/src/commonMain/kotlin/com/xebia/functional/loaders/TextLoader.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/loaders/TextLoader.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.loaders
 
-import com.xebia.functional.domain.Document
+import com.xebia.functional.Document
 import com.xebia.functional.textsplitters.BaseTextSplitter
 import okio.FileSystem
 import okio.Path

--- a/src/commonMain/kotlin/com/xebia/functional/textsplitters/BaseTextSplitter.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/textsplitters/BaseTextSplitter.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.textsplitters
 
-import com.xebia.functional.domain.Document
+import com.xebia.functional.Document
 
 interface BaseTextSplitter {
     suspend fun splitText(text: String): List<String>

--- a/src/commonMain/kotlin/com/xebia/functional/textsplitters/CharacterTextSplitter.kt
+++ b/src/commonMain/kotlin/com/xebia/functional/textsplitters/CharacterTextSplitter.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.textsplitters
 
-import com.xebia.functional.domain.Document
+import com.xebia.functional.Document
 
 suspend fun CharacterTextSplitter(
     separator: String

--- a/src/commonTest/kotlin/com/xebia/functional/loaders/TextLoaderSpec.kt
+++ b/src/commonTest/kotlin/com/xebia/functional/loaders/TextLoaderSpec.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.loaders
 
-import com.xebia.functional.domain.Document
+import com.xebia.functional.Document
 import com.xebia.functional.textsplitters.CharacterTextSplitter
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/src/commonTest/kotlin/com/xebia/functional/textsplitters/CharacterTextSplitterSpec.kt
+++ b/src/commonTest/kotlin/com/xebia/functional/textsplitters/CharacterTextSplitterSpec.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.textsplitters
 
-import com.xebia.functional.domain.Document
+import com.xebia.functional.Document
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 


### PR DESCRIPTION
Seems that `Document` model was duplicated, this PR keeps only one and removes the other.