### PR TITLE
Enable publication of langchain4k-filesystem

### DIFF
--- a/langchain4k-filesystem/build.gradle.kts
+++ b/langchain4k-filesystem/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.kotlinx.serialization)
   alias(libs.plugins.spotless)
   alias(libs.plugins.arrow.gradle.publish)
 }


### PR DESCRIPTION
It was not published, so I lost access to the `io` module that was before within `langchain4k`.