### PR TITLE
Setup JUnit5 for jvmTest

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -26,17 +26,12 @@ java {
 kotlin {
   jvm {
     compilations {
-      val main by getting
       val integrationTest by compilations.creating {
         // Create a test task to run the tests produced by this compilation:
         tasks.register<Test>("integrationTest") {
           description = "Run the integration tests"
           group = "verification"
-          // Run the tests with the classpath containing the compile dependencies (including 'main'),
-          // runtime dependencies, and the outputs of this compilation:
           classpath = compileDependencyFiles + runtimeDependencyFiles + output.allOutputs
-
-          // Run only the tests from this compilation's outputs:
           testClassesDirs = output.classesDirs
 
           testLogging {
@@ -44,6 +39,8 @@ kotlin {
           }
         }
       }
+      val test by compilations.getting
+      integrationTest.associateWith(test)
     }
   }
   js(IR) {
@@ -118,8 +115,6 @@ kotlin {
     val mingwX64Test by getting
 
     val jvmIntegrationTest by getting {
-      dependsOn(jvmMain)
-      dependsOn(jvmTest)
       dependencies {
         implementation(libs.kotest.testcontainers)
         implementation(libs.testcontainers.postgresql)


### PR DESCRIPTION
Before:

```text
org.gradle.api.internal.tasks.testing.TestSuiteExecutionException: Could not start Gradle Test Executor 60.
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.startProcessing(SuiteTestClassProcessor.java:44)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base@11.0.10/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@11.0.10/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.startProcessing(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$1.run(TestWorker.java:161)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: org.junit.platform.commons.PreconditionViolationException: Cannot create Launcher without at least one TestEngine; consider adding an engine implementation JAR to the classpath
	at app//org.junit.platform.commons.util.Preconditions.condition(Preconditions.java:296)
	at app//org.junit.platform.launcher.core.DefaultLauncher.<init>(DefaultLauncher.java:55)
	at app//org.junit.platform.launcher.core.LauncherFactory.createDefaultLauncher(LauncherFactory.java:134)
	at app//org.junit.platform.launcher.core.LauncherFactory.openSession(LauncherFactory.java:98)
	at app//org.junit.platform.launcher.core.LauncherFactory.openSession(LauncherFactory.java:82)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$BackwardsCompatibleLauncherSession.open(JUnitPlatformTestClassProcessor.java:256)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.createTestExecutor(JUnitPlatformTestClassProcessor.java:77)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.startProcessing(AbstractJUnitTestClassProcessor.java:50)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.startProcessing(SuiteTestClassProcessor.java:42)
	... 18 more
```

After it works correctly and we can run `./gradlew build` and `./gradlew integrationTest`.
However, my IDEA is currently broken 😭 Everything in `commonTest` is red.

<img width="925" alt="Screenshot 2023-05-08 at 11 54 54" src="https://user-images.githubusercontent.com/12424668/236794460-04c96814-e449-49a6-a9fc-592e5337f824.png">
