### PR TITLE
Making validation errors in SequenceChain accumulative

### DIFF
--- a/kotlin/src/commonMain/kotlin/com/xebia/functional/chains/SequenceChain.kt
+++ b/kotlin/src/commonMain/kotlin/com/xebia/functional/chains/SequenceChain.kt
@@ -51,12 +51,10 @@ open class SequenceChain(
             either {
                 val allOutputs = chains.map { it.config.outputKeys }.toSet().flatten()
                 val mappedChains: List<Chain> = recover({
-                  chains.map { chain ->
-                        zipOrAccumulate(
-                            { validateSequenceOutputs(outputVariables, allOutputs) },
-                            { validateInputsOverlapping(inputVariables, allOutputs) },
-                        ) { _, _ -> chain }
-                    }
+                    zipOrAccumulate(
+                        { validateSequenceOutputs(outputVariables, allOutputs) },
+                        { validateInputsOverlapping(inputVariables, allOutputs) },
+                    ) { _, _ -> chains }
                 }) { raise(InvalidKeys(reason = it.joinToString(transform = Chain.Error::reason))) }
                 SequenceChain(mappedChains, inputVariables, outputVariables, chainOutput)
             }

--- a/kotlin/src/commonTest/kotlin/com/xebia/functional/chains/SequenceChainSpec.kt
+++ b/kotlin/src/commonTest/kotlin/com/xebia/functional/chains/SequenceChainSpec.kt
@@ -116,4 +116,23 @@ class SequenceChainSpec : StringSpec({
             sc.run(mapOf("foo" to "123")).bind()
         } shouldBeLeft SequenceChain.InvalidKeys("The provided inputs: {foo}, {test} overlap with chain's outputs: {bar}, {test}, {baz}")
     }
+
+    "SequenceChain should fail when output variables are missing and input variables are overlapping" {
+        val chain1 = FakeChain(inputVariables = setOf("foo"), outputVariables = setOf("bar"))
+        val chain2 = FakeChain(inputVariables = setOf("bar"), outputVariables = setOf("baz"))
+        val chains = listOf(chain1, chain2)
+
+        either {
+            val sc = SequenceChain.either(
+                chains = chains,
+                inputVariables = listOf("foo", "bar"),
+                outputVariables = listOf("potato"),
+                chainOutput = Chain.ChainOutput.InputAndOutput
+            ).bind()
+            sc.run(mapOf("foo" to "123")).bind()
+        } shouldBeLeft SequenceChain.InvalidKeys(
+            "The provided outputs: {potato} do not exist in chains' outputs: {bar}, {baz}, " +
+                    "The provided inputs: {foo}, {bar} overlap with chain's outputs: {bar}, {baz}"
+        )
+    }
 })


### PR DESCRIPTION
Currently, if one validation on `SequenceChain.either` fails the flow will circuit-break. In this PR we are making the validation accumulative.

A test was added to check this accumulative behavior.