### PR TITLE
IA and prompt functions

### DIFF
--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/ASCIIArt.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/ASCIIArt.kt
@@ -1,7 +1,7 @@
 package com.xebia.functional.langchain4k.auto
 
 import com.xebia.functional.auto.AI
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 data class ASCIIArt(val art: String)
 
 suspend fun main() {
-    val art: AI<ASCIIArt> = prompt {
+    val art: AI<ASCIIArt> = ai {
         prompt("ASCII art of a cat dancing")
     }
     println(art.getOrElse { ASCIIArt("¯\\_(ツ)_/¯" + "\n" + it.reason) })

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Animal.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Animal.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -14,7 +14,7 @@ data class Invention(val name: String, val inventor: String, val year: Int, val 
 data class Story(val animal: Animal, val invention: Invention, val story: String)
 
 suspend fun main() {
-    prompt {
+    ai {
       val animal: Animal = prompt("A unique animal species.")
       val invention: Invention = prompt("A groundbreaking invention from the 20th century.")
 

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Book.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Book.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Book(val title: String, val author: String, val summary: String)
 
 suspend fun main() {
-    prompt {
+    ai {
         val toKillAMockingbird: Book = prompt("To Kill a Mockingbird by Harper Lee summary.")
         println("To Kill a Mockingbird summary:\n ${toKillAMockingbird.summary}")
     }.getOrElse { println(it) }

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/BreakingNews.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/BreakingNews.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import com.xebia.functional.tool.search
 import kotlinx.serialization.Serializable
@@ -13,7 +13,7 @@ data class BreakingNewsAboutCovid(
 )
 
 suspend fun main() {
-  prompt {
+  ai {
     val sdf = SimpleDateFormat("dd/M/yyyy")
     val currentDate = sdf.format(Date())
     agent(search("$currentDate Covid News")) {

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/ChessAI.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/ChessAI.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -12,7 +12,7 @@ data class ChessBoard(val board: String)
 data class GameState(val ended: Boolean, val winner: String)
 
 suspend fun main() {
-    prompt {
+    ai {
       val moves = mutableListOf<ChessMove>()
       var gameEnded = false
       var winner = ""

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Colors.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Colors.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Colors(val colors: List<String>)
 
 suspend fun main() {
-    prompt {
+    ai {
         val colors: Colors = prompt("a selection of 10 beautiful colors that go well together")
         println(colors)
     }.getOrElse { println(it) }

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/DivergentTasks.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/DivergentTasks.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import com.xebia.functional.tool.search
 import kotlinx.serialization.Serializable
@@ -10,7 +10,7 @@ data class NumberOfMedicalNeedlesInWorld(val numberOfNeedles: Long)
 
 
 suspend fun main() {
-    prompt {
+    ai {
         agent(search("Estimate amount of medical needles in the world")) {
             val needlesInWorld: NumberOfMedicalNeedlesInWorld =
                 prompt("Provide the number of medical needles in the world")

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Employee.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Employee.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -14,7 +14,7 @@ data class Address(val street: String, val city: String, val country: String)
 data class Company(val name: String, val address: Address)
 
 suspend fun main() {
-    prompt {
+    ai {
       val complexPrompt =
         """|
                  |Provide made up information for an Employee that includes their first name, last name, age, position, and their company's name and address (street, city, and country).

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Fact.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Fact.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Fact(val topic: String, val content: String)
 
 suspend fun main() {
-    prompt {
+    ai {
       val fact1: Fact = prompt("A fascinating fact about you")
       val fact2: Fact = prompt("An interesting fact about me")
 

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Love.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Love.kt
@@ -1,10 +1,10 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 
 suspend fun main() {
-  prompt {
+  ai {
     val love: List<String> = prompt("tell me you like me with just emojis")
     println(love)
   }.getOrElse { println(it) }

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Markets.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Markets.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import com.xebia.functional.tool.search
 import kotlinx.serialization.Serializable
@@ -15,7 +15,7 @@ data class MarketNews(
 )
 
 suspend fun main() {
-  prompt {
+  ai {
     val sdf = SimpleDateFormat("dd/M/yyyy")
     val currentDate = sdf.format(Date())
     agent(search("$currentDate Stock market results, raising stocks, decreasing stocks")) {

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/MealPlan.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/MealPlan.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import com.xebia.functional.tool.search
 import kotlinx.serialization.Serializable
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 data class MealPlan(val name: String, val recipes: List<Recipe>)
 
 suspend fun main() {
-    prompt {
+    ai {
         agent(search("gall bladder stones meals")) {
             val mealPlan: MealPlan = prompt(
                 "Meal plan for the week for a person with gall bladder stones that includes 5 recipes."

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/MeaningOfLife.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/MeaningOfLife.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class MeaningOfLife(val mainTheories: List<String>)
 
 suspend fun main() {
-    prompt {
+    ai {
         val meaningOfLife: MeaningOfLife = prompt("What are the main theories about the meaning of life")
         println("There are several theories about the meaning of life:\n ${meaningOfLife.mainTheories}")
     }.getOrElse { println(it) }

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Movie.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Movie.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Movie(val title: String, val genre: String, val director: String)
 
 suspend fun main() {
-    prompt {
+    ai {
         val movie: Movie = prompt("Inception movie genre and director.")
         println("The movie ${movie.title} is a ${movie.genre} film directed by ${movie.director}.")
     }.getOrElse { println(it) }

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Person.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Person.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Person(val name: String, val age: Int)
 
 suspend fun main() {
-    prompt {
+    ai {
         val person: Person = prompt("What is your name and age?")
         println("Hello ${person.name}, you are ${person.age} years old.")
     }.getOrElse { println(it) }

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Planet.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Planet.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -11,7 +11,7 @@ data class Planet(val name: String, val distanceFromSun: Double, val moons: List
 data class Moon(val name: String, val distanceFromPlanet: Double)
 
 suspend fun main() =
-    prompt {
+    ai {
       val earth: Planet = prompt("Information about Earth and its moon.")
       val mars: Planet = prompt("Information about Mars and its moons.")
 

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Poem.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Poem.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Poem(val title: String, val content: String)
 
 suspend fun main() =
-    prompt {
+    ai {
       val poem1: Poem = prompt("A short poem about the beauty of nature.")
       val poem2: Poem = prompt("A short poem about the power of technology.")
       val poem3: Poem = prompt("A short poem about the wisdom of artificial intelligence.")

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Population.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Population.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Population(val size: Int, val description: String)
 
 suspend fun main() =
-    prompt {
+    ai {
         val cadiz: Population = prompt("Population of Cádiz, Spain.")
         val seattle: Population = prompt("Population of Seattle, WA.")
         println("The population of Cádiz is ${cadiz.size} and the population of Seattle is ${seattle.size}")

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Recipe.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/Recipe.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class Recipe(val name: String, val ingredients: List<String>)
 
 suspend fun main() =
-    prompt {
+    ai {
         val recipe: Recipe = prompt("Recipe for chocolate chip cookies.")
         println("The recipe for ${recipe.name} is ${recipe.ingredients}")
     }.getOrElse { println(it) }

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/TopAttraction.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/TopAttraction.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -13,7 +13,7 @@ data class City(val name: String, val country: String)
 @Serializable
 data class Weather(val city: City, val temperature: Double, val description: String)
 
-suspend fun main() = prompt {
+suspend fun main() = ai {
   val nearbyTopAttraction: TopAttraction = prompt("Top attraction in Cádiz, Spain.")
   println(
       """

--- a/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/TouristAttraction.kt
+++ b/example/src/main/kotlin/com/xebia/functional/langchain4k/auto/TouristAttraction.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.langchain4k.auto
 
-import com.xebia.functional.auto.prompt
+import com.xebia.functional.auto.ai
 import com.xebia.functional.auto.getOrElse
 import kotlinx.serialization.Serializable
 
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class TouristAttraction(val name: String, val location: String, val history: String)
 
 suspend fun main() =
-    prompt {
+    ai {
         val statueOfLiberty: TouristAttraction = prompt("Statue of Liberty location and history.")
         println(
             """|${statueOfLiberty.name} is located in ${statueOfLiberty.location} and has the following history:

--- a/kotlin/src/commonMain/kotlin/com/xebia/functional/auto/AI.kt
+++ b/kotlin/src/commonMain/kotlin/com/xebia/functional/auto/AI.kt
@@ -12,7 +12,6 @@ import arrow.fx.coroutines.resourceScope
 import com.xebia.functional.AIError
 import com.xebia.functional.auto.serialization.buildJsonSchema
 import com.xebia.functional.auto.serialization.sample
-import com.xebia.functional.chains.Chain
 import com.xebia.functional.chains.VectorQAChain
 import com.xebia.functional.embeddings.OpenAIEmbeddings
 import com.xebia.functional.env.OpenAIConfig
@@ -51,7 +50,7 @@ data class SerializationConfig<A>(
  */
 typealias AI<A> = suspend AIScope.() -> A
 
-inline fun <A> prompt(noinline block: suspend AIScope.() -> A): AI<A> = block
+inline fun <A> ai(noinline block: suspend AIScope.() -> A): AI<A> = block
 
 @OptIn(ExperimentalTime::class)
 suspend inline fun <reified A> AI<A>.getOrElse(crossinline orElse: suspend (AIError) -> A): A =
@@ -68,7 +67,7 @@ suspend inline fun <reified A> AI<A>.getOrElse(crossinline orElse: suspend (AIEr
   }
 
 suspend inline fun <reified A> AI<A>.toEither(): Either<AIError, A> =
-  prompt { invoke().right() }.getOrElse { it.left() }
+  ai { invoke().right() }.getOrElse { it.left() }
 
 // TODO: Allow traced transformation of Raise errors
 class AIException(message: String) : RuntimeException(message)


### PR DESCRIPTION
This PR fixes a naming issue: `ai` VS `prompt`, that by mistake, I introduced in https://github.com/xebia-functional/langchain4k/pull/40. This way, I have the intended syntax:

```kotlin
    val art: AI<ASCIIArt> = ai {
        prompt("ASCII art of a cat dancing")
    }
    println(art.getOrElse { ASCIIArt("¯\\_(ツ)_/¯" + "\n" + it.reason) })
```

Notice the outer `ai` and the inner `prompt`.