### PR TITLE
Set up GitHub Actions concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request sets up the GitHub Actions workflow that builds the code only to allow one concurrent job at a time. This prevents multiple builds from running when submitting several commits in a short time, which will enable us to save minutes.