### PR TITLE
Separate PostgreSQL

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -74,8 +74,6 @@ kotlin {
 
     val jvmMain by getting {
       dependencies {
-        implementation(libs.hikari)
-        implementation(libs.postgresql)
         api(libs.ktor.client.cio)
         implementation(libs.logback)
         implementation(libs.jtokk.it)
@@ -117,13 +115,6 @@ kotlin {
     val linuxX64Test by getting
     val macosX64Test by getting
     val mingwX64Test by getting
-
-    val jvmIntegrationTest by getting {
-      dependencies {
-        implementation(libs.kotest.testcontainers)
-        implementation(libs.testcontainers.postgresql)
-      }
-    }
 
     create("nativeMain") {
       dependsOn(commonMain)

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/embeddings/mock/Mock.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/embeddings/mock/Mock.kt
@@ -1,5 +1,7 @@
-package com.xebia.functional.xef.embeddings
+package com.xebia.functional.xef.embeddings.mock
 
+import com.xebia.functional.xef.embeddings.Embedding
+import com.xebia.functional.xef.embeddings.Embeddings
 import com.xebia.functional.xef.llm.openai.RequestConfig
 
 fun Embeddings.Companion.mock(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ scrapeit = "1.1.5"
 jtokkit = "0.4.0"
 rssreader = "3.4.4"
 lucene = "9.6.0"
+junit = "5.9.3"
 
 [libraries]
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
@@ -58,6 +59,7 @@ kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest"
 kotest-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-testcontainers = { module = "io.kotest.extensions:kotest-extensions-testcontainers", version.ref = "kotest-testcontainers" }
 kotest-assertions-arrow = { module = "io.kotest.extensions:kotest-assertions-arrow", version.ref = "kotest-arrow" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 uuid = { module = "app.softwork:kotlinx-uuid-core", version.ref = "uuid" }
 klogging = { module = "io.github.oshai:kotlin-logging", version.ref = "klogging"  }
 hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }

--- a/integrations/postgresql/build.gradle.kts
+++ b/integrations/postgresql/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+    id(libs.plugins.kotlinx.serialization.get().pluginId)
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+dependencies {
+    implementation(projects.xefCore)
+    implementation(libs.uuid)
+    implementation(libs.hikari)
+    implementation(libs.postgresql)
+
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.kotest.property)
+    testImplementation(libs.kotest.framework)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.kotest.testcontainers)
+    testImplementation(libs.testcontainers.postgresql)
+    testRuntimeOnly(libs.kotest.junit5)
+}

--- a/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/PostgreSQLVectorStore.kt
+++ b/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/PostgreSQLVectorStore.kt
@@ -1,20 +1,9 @@
-package com.xebia.functional.xef
+package com.xebia.functional.xef.vectorstores
 
 import com.xebia.functional.xef.embeddings.Embedding
 import com.xebia.functional.xef.embeddings.Embeddings
 import com.xebia.functional.xef.llm.openai.RequestConfig
-import com.xebia.functional.xef.vectorstores.PGCollection
-import com.xebia.functional.xef.vectorstores.PGDistanceStrategy
-import com.xebia.functional.xef.vectorstores.VectorStore
-import com.xebia.functional.xef.vectorstores.addNewCollection
-import com.xebia.functional.xef.vectorstores.addNewText
-import com.xebia.functional.xef.vectorstores.addVectorExtension
-import com.xebia.functional.xef.vectorstores.createCollectionsTable
-import com.xebia.functional.xef.vectorstores.createEmbeddingTable
-import com.xebia.functional.xef.vectorstores.deleteCollection
-import com.xebia.functional.xef.vectorstores.deleteCollectionDocs
-import com.xebia.functional.xef.vectorstores.getCollection
-import com.xebia.functional.xef.vectorstores.searchSimilarDocument
+import com.xebia.functional.xef.vectorstores.postgresql.*
 import javax.sql.DataSource
 import kotlinx.uuid.UUID
 import kotlinx.uuid.generateUUID

--- a/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/postgresql/JDBCSyntax.kt
+++ b/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/postgresql/JDBCSyntax.kt
@@ -1,4 +1,4 @@
-package com.xebia.functional.xef
+package com.xebia.functional.xef.vectorstores.postgresql
 
 import arrow.core.raise.NullableRaise
 import arrow.core.raise.nullable

--- a/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/postgresql/postgres.kt
+++ b/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/postgresql/postgres.kt
@@ -1,4 +1,4 @@
-package com.xebia.functional.xef.vectorstores
+package com.xebia.functional.xef.vectorstores.postgresql
 
 import kotlinx.uuid.UUID
 

--- a/integrations/postgresql/src/test/kotlin/xef/PGVectorStoreSpec.kt
+++ b/integrations/postgresql/src/test/kotlin/xef/PGVectorStoreSpec.kt
@@ -1,11 +1,12 @@
-package com.xebia.functional.xef
+package xef
 
 import com.xebia.functional.xef.embeddings.Embedding
 import com.xebia.functional.xef.embeddings.Embeddings
-import com.xebia.functional.xef.embeddings.mock
+import com.xebia.functional.xef.embeddings.mock.mock
 import com.xebia.functional.xef.llm.openai.EmbeddingModel
 import com.xebia.functional.xef.llm.openai.RequestConfig
-import com.xebia.functional.xef.vectorstores.PGDistanceStrategy
+import com.xebia.functional.xef.vectorstores.PGVectorStore
+import com.xebia.functional.xef.vectorstores.postgresql.PGDistanceStrategy
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.core.extensions.install

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,6 @@ project(":xef-core").projectDir = file("core")
 
 include("xef-lucene")
 project(":xef-lucene").projectDir = file("integrations/lucene")
+
+include("xef-postgresql")
+project(":xef-postgresql").projectDir = file("integrations/postgresql")


### PR DESCRIPTION
Following the idea discussed in the channel of making the core library as small as possible, this PR separates the parts about PostgreSQL into its own library. There might be a possibility of making this work for all JDBC clients, but at this moment it's just a copy of what was already there.