### PR TITLE
Enable publish plugin for kotlin-loom module

### DIFF
--- a/kotlin-loom/build.gradle.kts
+++ b/kotlin-loom/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id(libs.plugins.kotlin.jvm.get().pluginId)
   alias(libs.plugins.spotless)
+  alias(libs.plugins.arrow.gradle.publish)
 }
 
 repositories {


### PR DESCRIPTION
This pull request enables the `publish` plugin for the `kotlin-loom` module