### PR TITLE
Enable assemble task for Scala using Java 19

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assemble -x:kotlin-loom:assemble -Pversion=${{ inputs.version }}
+          arguments: assemble -x:kotlin-loom:assemble -x:xef-scala:assemble -Pversion=${{ inputs.version }}
 
       - name: Upload reports
         if: failure()
@@ -45,9 +45,9 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype -x:kotlin-loom:closeSonatypeStagingRepository
+          arguments: -Pversion=${{ inputs.version }} publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype -x:kotlin-loom:closeSonatypeStagingRepository -x:xef-scala:publishToSonatype -x:xef-scala:closeSonatypeStagingRepository
 
-  publish-kotlin-loom:
+  publish-modules-with-loom:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -64,7 +64,7 @@ jobs:
       - name: assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :kotlin-loom:assemble -Pversion=${{ inputs.version }}
+          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:assemble :xef-scala:assemble
 
       - name: Upload reports
         if: failure()
@@ -76,4 +76,4 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:publishToSonatype :kotlin-loom:closeSonatypeStagingRepository
+          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:publishToSonatype :kotlin-loom:closeSonatypeStagingRepository :xef-scala:publishToSonatype :xef-scala:closeSonatypeStagingRepository

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,7 +29,7 @@ jobs:
       - name: assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assemble -x:kotlin-loom:assemble
+          arguments: assemble -x:kotlin-loom:assemble -x:xef-scala:assemble
 
       - name: Upload reports
         if: failure()
@@ -41,9 +41,9 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=0.0.1-SNAPSHOT publishToSonatype -x:kotlin-loom:publishToSonatype
+          arguments: -Pversion=0.0.1-SNAPSHOT publishToSonatype -x:kotlin-loom:publishToSonatype -x:xef-scala:publishToSonatype
 
-  publish-kotlin-loom:
+  publish-modules-with-loom:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -60,7 +60,7 @@ jobs:
       - name: assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :kotlin-loom:assemble -Pversion=${{ inputs.version }}
+          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:assemble :xef-scala:assemble
 
       - name: Upload reports
         if: failure()
@@ -72,4 +72,4 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=0.0.1-SNAPSHOT :kotlin-loom:publishToSonatype
+          arguments: -Pversion=0.0.1-SNAPSHOT :kotlin-loom:publishToSonatype :xef-scala:publishToSonatype


### PR DESCRIPTION
The workflow to publish the Snapshot artifacts for the Scala module is failing because the Scala module depends on Kotlin Loom, which needs Java 19. This pull request proposes a change to move the publication process for Scala to the job that uses Java 19.

@xebia-functional/team-ai Ready for review