### PR TITLE
Remove publishing tasks for Scala module

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype -x:kotlin-loom:closeSonatypeStagingRepository -x:xef-scala:publishToSonatype -x:xef-scala:closeSonatypeStagingRepository
+          arguments: -Pversion=${{ inputs.version }} publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype -x:kotlin-loom:closeSonatypeStagingRepository
 
   publish-modules-with-loom:
     timeout-minutes: 30
@@ -76,4 +76,4 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:publishToSonatype :kotlin-loom:closeSonatypeStagingRepository :xef-scala:publishToSonatype :xef-scala:closeSonatypeStagingRepository
+          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:publishToSonatype :kotlin-loom:closeSonatypeStagingRepository

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=0.0.1-SNAPSHOT publishToSonatype -x:kotlin-loom:publishToSonatype -x:xef-scala:publishToSonatype
+          arguments: -Pversion=0.0.1-SNAPSHOT publishToSonatype -x:kotlin-loom:publishToSonatype
 
   publish-modules-with-loom:
     timeout-minutes: 30
@@ -72,4 +72,4 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=0.0.1-SNAPSHOT :kotlin-loom:publishToSonatype :xef-scala:publishToSonatype
+          arguments: -Pversion=0.0.1-SNAPSHOT :kotlin-loom:publishToSonatype


### PR DESCRIPTION
The `xef-scala` module is not yet set up to publish artifacts, so we remove the `publishing` tasks.