### PR TITLE
Fix problem with deserializer

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/DeserializerLLMAgent.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/DeserializerLLMAgent.kt
@@ -144,9 +144,11 @@ suspend fun <A> AIScope.tryDeserialize(
     currentAttempts++
     val result = ensureNotNull(agent().firstOrNull()) { AIError.NoResponse }
     catch({
-      return@tryDeserialize json.decodeFromString(serializationConfig.deserializationStrategy, result)
-    }) {
-      e: IllegalArgumentException ->
+      return@tryDeserialize json.decodeFromString(
+        serializationConfig.deserializationStrategy,
+        result
+      )
+    }) { e: IllegalArgumentException ->
       if (currentAttempts == maxDeserializationAttempts)
         raise(AIError.JsonParsing(result, maxDeserializationAttempts, e))
       // else continue with the next attempt


### PR DESCRIPTION
During the agent refactoring this function was incorrectly changed (by me 😓). This PR simply adds the missing `return` which exits from the function when deserialization is successful.