### PR TITLE
AI.contextScope resources

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AI.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AI.kt
@@ -25,8 +25,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.json.JsonObject
 
-@DslMarker
-annotation class AiDsl
+@DslMarker annotation class AiDsl
 
 data class SerializationConfig<A>(
   val jsonSchema: JsonObject,
@@ -147,9 +146,7 @@ class AIScope(
    * }
    * ```
    */
-  @AiDsl
-  @JvmName("invokeAI")
-  suspend operator fun <A> AI<A>.invoke(): A = invoke(this@AIScope)
+  @AiDsl @JvmName("invokeAI") suspend operator fun <A> AI<A>.invoke(): A = invoke(this@AIScope)
 
   @AiDsl
   suspend fun extendContext(vararg docs: String) {
@@ -157,9 +154,9 @@ class AIScope(
   }
 
   /**
-   * Creates a new scoped [VectorStore] using [store], which is scoped to the [block] lambda.
-   * The [block] also runs on a _nested_ [resourceScope],
-   * meaning that all additional resources created within [block] will be finalized after [block] finishes.
+   * Creates a new scoped [VectorStore] using [store], which is scoped to the [block] lambda. The
+   * [block] also runs on a _nested_ [resourceScope], meaning that all additional resources created
+   * within [block] will be finalized after [block] finishes.
    */
   @AiDsl
   suspend fun <A> contextScope(
@@ -168,13 +165,14 @@ class AIScope(
   ): A = resourceScope {
     val newStore = store(this@AIScope.embeddings)
     AIScope(
-      this@AIScope.openAIClient,
-      CombinedVectorStore(newStore, this@AIScope.context),
-      this@AIScope.embeddings,
-      this@AIScope.logger,
-      this,
-      this@AIScope
-    ).block()
+        this@AIScope.openAIClient,
+        CombinedVectorStore(newStore, this@AIScope.context),
+        this@AIScope.embeddings,
+        this@AIScope.logger,
+        this,
+        this@AIScope
+      )
+      .block()
   }
 
   @AiDsl
@@ -182,9 +180,8 @@ class AIScope(
 
   /** Add new [docs] to the [context], and then executes the [block]. */
   @AiDsl
-  suspend fun <A> contextScope(docs: List<String>, block: AI<A>): A =
-    contextScope {
-      extendContext(*docs.toTypedArray())
-      block(this)
-    }
+  suspend fun <A> contextScope(docs: List<String>, block: AI<A>): A = contextScope {
+    extendContext(*docs.toTypedArray())
+    block(this)
+  }
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
@@ -10,8 +10,9 @@ import com.xebia.functional.xef.llm.openai.EmbeddingModel
 import com.xebia.functional.xef.llm.openai.RequestConfig
 import kotlin.math.sqrt
 
-val LocalVectorStoreBuilder: suspend ResourceScope.(Embeddings) -> LocalVectorStore =
-  { e -> LocalVectorStore(e) }
+val LocalVectorStoreBuilder: suspend ResourceScope.(Embeddings) -> LocalVectorStore = { e ->
+  LocalVectorStore(e)
+}
 
 class LocalVectorStore
 private constructor(
@@ -46,8 +47,8 @@ private constructor(
 
   override suspend fun similaritySearchByVector(embedding: Embedding, limit: Int): List<String> =
     atomically {
-      documents.read().mapNotNull { doc -> precomputedEmbeddings[doc]?.let { doc to it } }
-    }
+        documents.read().mapNotNull { doc -> precomputedEmbeddings[doc]?.let { doc to it } }
+      }
       .map { (doc, embedding) -> doc to embedding.cosineSimilarity(embedding) }
       .sortedByDescending { (_, similarity) -> similarity }
       .take(limit)


### PR DESCRIPTION
Previously the `store` build by `contextScope` was scoped to the `ResourceScope` of the entire `AI` DSL, but it's only used within the `block` of `contextScope`. Similarly, all the resources created within the `block` would also live for the entire `AIScope` lifecycle.
 
This PR creates a nested `resourceScope` for `contextScope` such that all the resources created within the nested DSL are scoped to the nested DSL itself.

@xebia-functional/team-ai @serras