### PR TITLE
Remove non existing Gradle tasks

### DIFF
--- a/.github/workflows/publish-development-version.yml
+++ b/.github/workflows/publish-development-version.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Publish development version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype -x:kotlin-loom:closeSonatypeStagingRepository -x:xef-scala:publishToSonatype -x:xef-scala:closeSonatypeStagingRepository
+          arguments: publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype
 
   publish-modules-with-loom:
     timeout-minutes: 30
@@ -78,4 +78,4 @@ jobs:
       - name: Publish development version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :kotlin-loom:publishToSonatype :kotlin-loom:closeSonatypeStagingRepository :xef-scala:publishToSonatype :xef-scala:closeSonatypeStagingRepository
+          arguments: :kotlin-loom:publishToSonatype closeSonatypeStagingRepository


### PR DESCRIPTION
The `closeSonatypeStagingRepository` task is only defined in the root project, so this pull request removes all the calls to this task from subprojects.