### PR TITLE
Close and release staging repos for development versions

### DIFF
--- a/.github/workflows/publish-development-version.yml
+++ b/.github/workflows/publish-development-version.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Publish development version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype --stacktrace
+          arguments: publishToSonatype -x:kotlin-loom:publishToSonatype closeAndReleaseSonatypeStagingRepository
 
   publish-modules-with-loom:
     timeout-minutes: 30
@@ -78,4 +78,4 @@ jobs:
       - name: Publish development version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :kotlin-loom:publishToSonatype closeSonatypeStagingRepository --stacktrace
+          arguments: :kotlin-loom:publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} publishToSonatype closeSonatypeStagingRepository -x:kotlin-loom:publishToSonatype -x:kotlin-loom:closeSonatypeStagingRepository
+          arguments: -Pversion=${{ inputs.version }} publishToSonatype -x:kotlin-loom:publishToSonatype closeSonatypeStagingRepository
 
   publish-modules-with-loom:
     timeout-minutes: 30
@@ -77,4 +77,4 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:publishToSonatype :kotlin-loom:closeSonatypeStagingRepository
+          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:publishToSonatype closeSonatypeStagingRepository


### PR DESCRIPTION
This pull request uses the `closeAndReleaseSonatypeStagingRepository` command to automatically release and sync the artifacts with Maven Central for the development versions (alpha, beta, and RC) once the build finishes successfully.