### PR TITLE
Improve error reporting when things fail

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/AIClientError.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/AIClientError.kt
@@ -2,6 +2,4 @@ package com.xebia.functional.xef.llm
 
 import kotlinx.serialization.json.JsonElement
 
-data class AIClientError(
-    val json: JsonElement
-): Exception("AI client error")
+data class AIClientError(val json: JsonElement) : Exception("AI client error")

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/openai/OpenAIClient.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/openai/OpenAIClient.kt
@@ -20,7 +20,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.internal.decodeStringToJsonTree
 
 private val logger: KLogger = KotlinLogging.logger {}
 
@@ -139,4 +138,3 @@ private suspend inline fun <reified T> HttpResponse.bodyOrError(): T {
     throw AIClientError(JsonLenient.decodeFromString<JsonElement>(contents))
   }
 }
-


### PR DESCRIPTION
Instead of blindly returning the "cannot deserialize" exception when an error arises in the OpenAI client (for example, because the API key is not valid), handle this and throw our own type of exception.

Ready for review @xebia-functional/team-ai 