### PR TITLE
Change project group to com.xebia

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ repositories {
 }
 ```
 
-Then add `com.47deg.xef:xef-<name>:0.0.1-SNAPSHOT` as a dependency, where `<name>` refers
+Then add `com.xebia:xef-<name>:0.0.1-alpha.<latest-alpha-version>` as a dependency, where `<name>` refers
 to the subcomponent you need:
 
 1. `xef-core` for Kotlin support, `xef-scala` for Scala.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 kotlin.code.style=official
 kotlin.js.compiler=ir
 
-project.group=com.47deg.xef
+project.group=com.xebia
 pom.name=xef
 pom.description=Building applications with LLMs through composability, in Kotlin
 pom.url=https://github.com/xebia-functional/xef
 pom.license.name=The Apache Software License, Version 2.0
 pom.license.url=https://www.apache.org/licenses/LICENSE-2.0.txt
-pom.developer.id=xebia-functional
-pom.developer.name=Xebia Functional
-pom.developer.email=developer@47deg.com
+pom.developer.id=xebia-functional-engineering
+pom.developer.name=Xebia Functional Engineering
+pom.developer.email=functional-ops@xebia.com
 pom.smc.url=https://github.com/xebia-functional/xef
 pom.smc.connection=scm:git:git://github.com/xebia-functional/xef.git
 pom.smc.developerConnection=scm:git:ssh://git@github.com/xebia-functional/xef.git


### PR DESCRIPTION
This pull request changes the project group used to publish the artifacts in Sonatype/Maven from `com.47deg.xef` to `com.xebia`.

We also should change the secrets that store the Sonatype credentials and the signing key before merging the pull request to ensure the artifacts are associated with the right staging profile in Sonatype.