### PR TITLE
OpenAI Client improvements

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/AIError.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/AIError.kt
@@ -2,7 +2,6 @@ package com.xebia.functional.xef
 
 import arrow.core.NonEmptyList
 import com.xebia.functional.xef.llm.openai.Message
-import kotlinx.serialization.json.JsonElement
 
 sealed interface AIError {
   val reason: String
@@ -11,19 +10,6 @@ sealed interface AIError {
     override val reason: String
       get() = "No response from the AI"
   }
-
-  sealed interface Client : AIError {
-    data class FailedParsing(val json: JsonElement, val cause: IllegalArgumentException) : Client {
-      override val reason: String
-        get() = "AIClient failed to parse response. Received $json, cause: ${cause.stackTraceToString()}"
-    }
-  }
-
-//  data class AIClient(val error: Throwable) : AIError {
-//    override val reason: String
-//      get() = TODO("Not yet implemented")
-//  }
-
 
   data class MessagesExceedMaxTokenLength(
     val messages: List<Message>,

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/embeddings/OpenAIEmbeddings.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/embeddings/OpenAIEmbeddings.kt
@@ -1,7 +1,6 @@
 package com.xebia.functional.xef.embeddings
 
 import arrow.fx.coroutines.parMap
-import arrow.resilience.retry
 import com.xebia.functional.xef.env.OpenAIConfig
 import com.xebia.functional.xef.llm.openai.EmbeddingRequest
 import com.xebia.functional.xef.llm.openai.OpenAIClient
@@ -37,7 +36,10 @@ class OpenAIEmbeddings(
     texts: List<String>,
     requestConfig: RequestConfig
   ): List<Embedding> =
-    oaiClient.createEmbeddings(EmbeddingRequest(requestConfig.model.modelName, texts, requestConfig.user.id))
+    oaiClient
+      .createEmbeddings(
+        EmbeddingRequest(requestConfig.model.modelName, texts, requestConfig.user.id)
+      )
       .data
       .map { Embedding(it.embedding) }
 }


### PR DESCRIPTION
# Embeddings

was duplicating the retrying mechanism that was already applied inside OpenAPI resulting in 2x retry strategy. This PR removes the duplication whilst maintaining the logging mechanism applied in Embeddings
 
# OpenAPI errors

We were throwing an exception when OpenAI returned a proper error response (429 + error json). This PR checks the status code and deserialises the error response from OpenAPI and throws an exception with proper error message. I choose to keep this as an exception, since for example in the case I am often seeing "429 Too Many Requests, You exceeded your current quota, please check your plan and billing details." there is not meaningful we can recover too.

Ready for review @xebia-functional/team-ai