### PR TITLE
xef-scala-cats module improvements

### DIFF
--- a/scala-cats/.scalafmt.conf
+++ b/scala-cats/.scalafmt.conf
@@ -1,6 +1,6 @@
 # tune this file as appropriate to your style!  see: https://olafurpg.github.io/scalafmt/#Configuration
 
-version = "3.7.1"
+version = "3.7.3"
 
 runner.dialect = "scala3"
 

--- a/scala-cats/README.md
+++ b/scala-cats/README.md
@@ -1,0 +1,9 @@
+# xef-scala-cats
+
+This module aims to integrate xef-core with [cats-effect](https://typelevel.org/cats-effect/) and IO.
+
+## Interoperability Coroutines & Cats-Effect's IO
+
+The `CoroutineToIO` is a wrapper implementation that originated from a post by Alexandru Nedelcu. 
+Therefore, any acknowledgments regarding this work should be directed toward him. The post can be 
+found in [his blog post](https://alexn.org/blog/2023/04/24/kotlin-suspended-functions-to-cats-effect-io/).

--- a/scala-cats/build.gradle.kts
+++ b/scala-cats/build.gradle.kts
@@ -10,28 +10,26 @@ plugins {
 
 dependencies {
     implementation(projects.xefCore)
-
-    // TODO split to separate Scala library
-    implementation(projects.xefPdf)
+    implementation(libs.scala.lang)
     implementation(libs.cats.effect)
-    implementation(libs.circe.parser)
-    implementation(libs.circe)
     testImplementation(libs.munit.core)
     testImplementation(libs.munit.cats.effect)
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_19
-    targetCompatibility = JavaVersion.VERSION_19
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
     toolchain {
-        languageVersion = JavaLanguageVersion.of(19)
+        languageVersion = JavaLanguageVersion.of(11)
     }
-    withSourcesJar()
-    withJavadocJar()
 }
 
 tasks.withType<Test>().configureEach {
     useJUnit()
+}
+
+tasks.withType<ScalaCompile> {
+    scalaCompileOptions.additionalParameters = listOf("-Wunused:all", "-Wvalue-discard")
 }
 
 publishing {
@@ -85,6 +83,6 @@ signing {
 
 spotless {
     scala {
-        scalafmt("3.7.1").configFile(".scalafmt.conf").scalaMajorVersion("2.13")
+        scalafmt("3.7.3").configFile(".scalafmt.conf").scalaMajorVersion("2.13")
     }
 }

--- a/scala-cats/src/main/scala/com/xebia/functional/xef/scala/kotlin/CoroutineToIO.scala
+++ b/scala-cats/src/main/scala/com/xebia/functional/xef/scala/kotlin/CoroutineToIO.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal


### PR DESCRIPTION
This PR:

* Adds a README file, giving credit to Alexandru Nedelcu for his post about wrapping Kotlin coroutines into Cats-Effect's IO
* Upgrades scalafmt
* Downgrades to Java 11 (initially, this module doesn't need Loom)
* Checks unused imports
* I hope it fixes [this build](https://github.com/xebia-functional/xef/actions/runs/5141616194/jobs/9254308861)