### PR TITLE
Improve publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,9 @@
-name: Publish stable version
+name: Publish final version
 
 on:
-  workflow_dispatch:
-    branches: [main]
-    inputs:
-      version:
-        description: 'Version'
-        required: true
-        type: string
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   OSS_USER: '${{ secrets.OSS_USER }}'
@@ -20,10 +16,12 @@ jobs:
   publish:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -31,10 +29,10 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
-      - name: assemble
+      - name: Assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assemble -x:kotlin-loom:assemble -x:xef-scala:assemble -Pversion=${{ inputs.version }}
+          arguments: assemble -x:kotlin-loom:assemble -x:xef-scala:assemble -x:xef-scala-examples:assemble
 
       - name: Upload reports
         if: failure()
@@ -46,7 +44,7 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} publishToSonatype -x:kotlin-loom:publishToSonatype -x:xef-scala:publishToSonatype closeSonatypeStagingRepository
+          arguments: publishToSonatype -x:kotlin-loom:publishToSonatype -x:xef-scala:publishToSonatype closeSonatypeStagingRepository
 
   publish-modules-with-loom:
     timeout-minutes: 30
@@ -55,6 +53,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -65,7 +64,7 @@ jobs:
       - name: assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:assemble :xef-scala:assemble
+          arguments: :kotlin-loom:assemble :xef-scala:assemble
 
       - name: Upload reports
         if: failure()
@@ -77,4 +76,4 @@ jobs:
       - name: Publish final version
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: -Pversion=${{ inputs.version }} :kotlin-loom:publishToSonatype :xef-scala:publishToSonatype closeSonatypeStagingRepository
+          arguments: :kotlin-loom:publishToSonatype :xef-scala:publishToSonatype closeSonatypeStagingRepository

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  `kotlin-dsl`
+}
+
+repositories {
+  mavenCentral()
+  gradlePluginPortal()
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,11 @@
+rootProject.name = "buildSrc"
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../gradle/libs.versions.toml"))
+      val kotlinVersion: String? by settings
+      kotlinVersion?.let { version("kotlin", it) }
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/ScalaDocumentationPlugin.kt
+++ b/buildSrc/src/main/kotlin/ScalaDocumentationPlugin.kt
@@ -1,0 +1,15 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.bundling.Jar
+
+class ScalaDocumentationPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    with(project) {
+      tasks.register("scaladocJar", Jar::class.java) {
+        archiveClassifier.set("javadoc")
+        dependsOn(tasks.named("scaladoc"))
+        from("${project.buildDir}/docs/scaladoc")
+      }
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/xef-scala-documentation.gradle.kts
+++ b/buildSrc/src/main/kotlin/xef-scala-documentation.gradle.kts
@@ -1,0 +1,1 @@
+apply<ScalaDocumentationPlugin>()

--- a/scala-cats/build.gradle.kts
+++ b/scala-cats/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     signing
     alias(libs.plugins.semver.gradle)
     alias(libs.plugins.spotless)
+    `xef-scala-documentation`
 }
 
 dependencies {
@@ -23,7 +24,6 @@ java {
         languageVersion = JavaLanguageVersion.of(11)
     }
     withSourcesJar()
-    withJavadocJar()
 }
 
 tasks.withType<Test>().configureEach {
@@ -36,9 +36,10 @@ tasks.withType<ScalaCompile> {
 
 publishing {
     publications {
-        create<MavenPublication>("maven") {
+        register<MavenPublication>("maven") {
             val scala3Suffix = "_3"
             from(components["java"])
+            artifact(tasks.named("scaladocJar"))
 
             artifactId = base.archivesName.get() + scala3Suffix
 

--- a/scala/build.gradle.kts
+++ b/scala/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     signing
     alias(libs.plugins.semver.gradle)
     alias(libs.plugins.spotless)
+    `xef-scala-documentation`
 }
 
 dependencies {
@@ -28,7 +29,6 @@ java {
         languageVersion = JavaLanguageVersion.of(19)
     }
     withSourcesJar()
-    withJavadocJar()
 }
 
 tasks.withType<Test>().configureEach {
@@ -41,9 +41,10 @@ tasks.withType<ScalaCompile> {
 
 publishing {
     publications {
-        create<MavenPublication>("maven") {
+        register<MavenPublication>("maven") {
             val scala3Suffix = "_3"
             from(components["java"])
+            artifact(tasks.named("scaladocJar"))
 
             artifactId = base.archivesName.get() + scala3Suffix
 


### PR DESCRIPTION
This pull request proposes two improvements to the publishing workflow:

- It generates the Scala documentation by running the `scaladoc` task provided by the Scala Gradle plugin. 
- It updates the workflow that publishes final versions to be triggered after creating a new final version tag.