### PR TITLE
Scala prompt templating

### DIFF
--- a/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
+++ b/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
@@ -1,0 +1,37 @@
+package com.xebia.functional.xef.scala.auto
+
+import com.xebia.functional.xef.scala.auto.*
+import com.xebia.functional.xef.scala.prompt.*
+import io.circe.Decoder
+
+final case class Play(title: String, era: String)
+
+final case class Synopsis(summary: String) derives PromptTemplate, Decoder, ScalaSerialDescriptor
+
+final case class Review(review: String) derives PromptTemplate, Decoder, ScalaSerialDescriptor
+
+@main def runSynopsisReview: Unit = {
+  def synopsisTemplate(play: Play): String =
+    s"""
+       |You are a playwright. Given the title of play and the era it is set in, it is your job to write a synopsis for that title.
+       |
+       |Title: ${play.title}.
+       |Era: ${play.era}.
+       |Playwright: This is a synopsis for the above play:
+      """.stripMargin
+
+  def reviewTemplate(synopsis: Synopsis): String =
+    s"""
+       |You are a play critic from the New York Times. Given the synopsis of play, it is your job to write a review for that play.
+       |
+       |Play Synopsis: ${synopsis.summary}.
+       |Review from a New York Times play critic of the above play:
+    """.stripMargin
+
+  ai {
+    val synopsisReview = PromptTemplate[Synopsis]
+      .create(synopsisTemplate(Play("The power of Zuluastral", "Modern Era")))
+      .add[Review](synopsis => reviewTemplate(synopsis))
+    println(synopsisReview.review)
+  }.getOrElse(ex => println(ex.getMessage))
+}

--- a/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
+++ b/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
@@ -28,8 +28,8 @@ final case class Review(review: String) derives PromptTemplate, Decoder, ScalaSe
        |Review from a New York Times play critic of the above play:
     """.stripMargin
 
-  val synopsisReview = PromptTemplate[Synopsis]
-    .create(synopsisTemplate(Play("The power of Zuluastral", "Modern Era")))
-    .add[Review](synopsis => reviewTemplate(synopsis))
-  println(synopsisReview.review)
+  val playReview = PromptTemplate[Synopsis]
+    .chain(synopsisTemplate(Play("The power of Zuluastral", "Modern Era")))
+    .chain[Review](synopsis => reviewTemplate(synopsis))
+  println(playReview.review)
 }

--- a/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
+++ b/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
@@ -4,11 +4,13 @@ import com.xebia.functional.xef.scala.auto.*
 import com.xebia.functional.xef.scala.prompt.*
 import io.circe.Decoder
 
-final case class Play(title: String, era: String)
+final case class Play(title: String, era: String) derives PromptTemplate, Decoder, ScalaSerialDescriptor
 
 final case class Synopsis(summary: String) derives PromptTemplate, Decoder, ScalaSerialDescriptor
 
 final case class Review(review: String) derives PromptTemplate, Decoder, ScalaSerialDescriptor
+
+final case class Score(score: Double) derives PromptTemplate, Decoder, ScalaSerialDescriptor
 
 @main def runSynopsisReview: Unit = {
   def synopsisTemplate(play: Play): String =
@@ -28,8 +30,18 @@ final case class Review(review: String) derives PromptTemplate, Decoder, ScalaSe
        |Review from a New York Times play critic of the above play:
     """.stripMargin
 
-  val playReview = PromptTemplate[Synopsis]
-    .chain(synopsisTemplate(Play("The power of Zuluastral", "Modern Era")))
+  def scoreTemplate(review: Review): String =
+    s"""
+       |You are an independent play critic scoring the best plays of the year.
+       |Given the review of the play, it is your job to score this play.
+       |
+       |Play Review: ${review.review}.
+       |Score the above play from 0 to 10:
+    """.stripMargin
+
+  val playScore = PromptTemplate[Play](Play("The power of Zuluastral", "Modern Era"))
+    .chain[Synopsis](play => synopsisTemplate(play))
     .chain[Review](synopsis => reviewTemplate(synopsis))
-  println(playReview.review)
+    .chain[Score](review => scoreTemplate(review))
+  println(s"Score (0 to 10): " + playScore.score)
 }

--- a/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
+++ b/examples/scala/src/main/scala/com/xebia/functional/xef/scala/auto/SynopsisReview.scala
@@ -28,10 +28,8 @@ final case class Review(review: String) derives PromptTemplate, Decoder, ScalaSe
        |Review from a New York Times play critic of the above play:
     """.stripMargin
 
-  ai {
-    val synopsisReview = PromptTemplate[Synopsis]
-      .create(synopsisTemplate(Play("The power of Zuluastral", "Modern Era")))
-      .add[Review](synopsis => reviewTemplate(synopsis))
-    println(synopsisReview.review)
-  }.getOrElse(ex => println(ex.getMessage))
+  val synopsisReview = PromptTemplate[Synopsis]
+    .create(synopsisTemplate(Play("The power of Zuluastral", "Modern Era")))
+    .add[Review](synopsis => reviewTemplate(synopsis))
+  println(synopsisReview.review)
 }

--- a/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
+++ b/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
@@ -5,10 +5,10 @@ import io.circe.Decoder
 
 trait PromptTemplate[A: ScalaSerialDescriptor: Decoder] {
 
-  def create(template: String): A
+  def chain(template: String): A
 
   extension (a: A) {
-    def add[B: ScalaSerialDescriptor: Decoder](template: A => String): B =
+    def chain[B: ScalaSerialDescriptor: Decoder](template: A => String): B =
       ai(prompt[B](template(a)))
   }
 }
@@ -18,4 +18,4 @@ object PromptTemplate:
   def apply[A](using ev: PromptTemplate[A]): PromptTemplate[A] = ev
 
   inline final def derived[A: ScalaSerialDescriptor: Decoder]: PromptTemplate[A] = new PromptTemplate[A]:
-    def create(template: String): A = ai(prompt[A](template))
+    def chain(template: String): A = ai(prompt[A](template))

--- a/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
+++ b/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
@@ -1,0 +1,21 @@
+package com.xebia.functional.xef.scala.prompt
+
+import com.xebia.functional.xef.scala.auto.*
+import io.circe.Decoder
+
+trait PromptTemplate[A: ScalaSerialDescriptor: Decoder] {
+
+  def create(template: String): A
+
+  extension (a: A) {
+    def add[B: ScalaSerialDescriptor: Decoder](template: A => String): B =
+      ai(prompt[B](template(a)))
+  }
+}
+
+object PromptTemplate:
+
+  def apply[A](using ev: PromptTemplate[A]): PromptTemplate[A] = ev
+
+  inline final def derived[A: ScalaSerialDescriptor: Decoder]: PromptTemplate[A] = new PromptTemplate[A]:
+    def create(template: String): A = ai(prompt[A](template))

--- a/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
+++ b/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
@@ -3,9 +3,9 @@ package com.xebia.functional.xef.scala.prompt
 import com.xebia.functional.xef.scala.auto.*
 import io.circe.Decoder
 
-trait PromptTemplate[A: ScalaSerialDescriptor: Decoder] {
+trait PromptTemplate[A] {
 
-  def chain(template: String): A
+  def chain[B: ScalaSerialDescriptor: Decoder](template: String): B
 
   extension (a: A) {
     def chain[B: ScalaSerialDescriptor: Decoder](template: A => String): B =
@@ -15,7 +15,8 @@ trait PromptTemplate[A: ScalaSerialDescriptor: Decoder] {
 
 object PromptTemplate:
 
-  def apply[A](using ev: PromptTemplate[A]): PromptTemplate[A] = ev
+  def apply[A](instance: A): A = instance
 
   inline final def derived[A: ScalaSerialDescriptor: Decoder]: PromptTemplate[A] = new PromptTemplate[A]:
-    def chain(template: String): A = ai(prompt[A](template))
+
+    def chain[B: ScalaSerialDescriptor: Decoder](template: String): B = ai(prompt[B](template))

--- a/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
+++ b/scala/src/main/scala/com/xebia/functional/xef/scala/prompt/PromptTemplate.scala
@@ -5,7 +5,7 @@ import io.circe.Decoder
 
 trait PromptTemplate[A] {
 
-  def chain[B: ScalaSerialDescriptor: Decoder](template: String): B
+  def chain(template: String): A
 
   extension (a: A) {
     def chain[B: ScalaSerialDescriptor: Decoder](template: A => String): B =
@@ -19,4 +19,4 @@ object PromptTemplate:
 
   inline final def derived[A: ScalaSerialDescriptor: Decoder]: PromptTemplate[A] = new PromptTemplate[A]:
 
-    def chain[B: ScalaSerialDescriptor: Decoder](template: String): B = ai(prompt[B](template))
+    def chain(template: String): A = ai(prompt[A](template))


### PR DESCRIPTION
Following on https://github.com/xebia-functional/xef/pull/143 comments, perhaps a more useful abstraction/templating could be done for a chain of prompts where one prompt response feeds the next prompt.

I have this initial version setup with an example included, let me know your thoughts on this.
