### PR TITLE
Redefines the Gradle build strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    strategy:
+      matrix:
+        platform: [ jvm, js, linuxX64, macosX64, mingwX64 ]
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -23,10 +27,30 @@ jobs:
           distribution: 'zulu'
           java-version: 19
 
-      - name: build
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build --full-stacktrace
+
+      - name: Build Multi-platform Modules
+        run: |
+          ./gradlew \
+            :xef-core:${{ matrix.platform }}Test \
+            :xef-filesystem:${{ matrix.platform }}Test \
+            :xef-tokenizer:${{ matrix.platform }}Test \
+            :xef-kotlin:${{ matrix.platform }}Test
+
+      - name: Build Single-platform Modules
+        if: matrix.platform == 'jvm'
+        run: |
+          ./gradlew \
+            :xef-lucene:build \
+            :xef-pdf:build \
+            :xef-postgresql:build \
+            :xef-sql:build \
+            :xef-kotlin-examples:build \
+            :kotlin-loom:build \
+            :xef-scala-examples:build \
+            :xef-scala:build \
+            :xef-scala-cats:build
 
       - name: Upload reports
         if: failure()


### PR DESCRIPTION
This PR could be considered a WIP, even if it's finally merged. Further iterations and optimizations will be required.

Initially, the objective of this PR is to decrease the build time. For that reason:

* I'm creating a pipeline matrix with the different platforms: `jvm`, `js`, `linuxX64`, `macosX64`, `mingwX64` (notice I've removed `macosArm64` due to some incompatibilities).
* I split the constructions and tests into _multi-platform_ and _single-platform_ (JVM). This could be done by creating the groups at the Gradle level, which could be the subject of further improvements.
* Regarding JS, I'm not building for browser and node, which might be required for certain modules, but I left that out of this work.

## Result

Hopefully, the build times should be reduced by more than 10 minutes.