### PR TITLE
Deleting Arrow STM

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -66,7 +66,6 @@ kotlin {
 
         api(libs.bundles.ktor.client)
         api(projects.xefTokenizer)
-        implementation(libs.arrow.fx.stm)
 
         // TODO split to a separate module
         implementation(libs.kotlinx.serialization.json)

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
@@ -1,24 +1,30 @@
 package com.xebia.functional.xef.vectorstores
 
-import arrow.fx.stm.TMap
-import arrow.fx.stm.TVar
-import arrow.fx.stm.atomically
+import arrow.atomic.Atomic
+import arrow.atomic.getAndUpdate
 import com.xebia.functional.xef.embeddings.Embedding
 import com.xebia.functional.xef.embeddings.Embeddings
 import com.xebia.functional.xef.llm.openai.EmbeddingModel
 import com.xebia.functional.xef.llm.openai.RequestConfig
 import kotlin.math.sqrt
 
+private data class State(val documents: List<String>, val precomputedEmbeddings: Map<String, Embedding>) {
+  companion object {
+    fun empty(): State = State(emptyList(), mapOf())
+  }
+}
+
+private typealias AtomicState = Atomic<State>
+
 class LocalVectorStore
 private constructor(
   private val embeddings: Embeddings,
-  private val documents: TVar<List<String>>,
-  private val precomputedEmbeddings: TMap<String, Embedding>
+  private val state: AtomicState
 ) : VectorStore {
 
   companion object {
     suspend operator fun invoke(embeddings: Embeddings) =
-      LocalVectorStore(embeddings, TVar.new(emptyList()), TMap.new())
+      LocalVectorStore(embeddings, Atomic(State.empty()))
   }
 
   private val requestConfig =
@@ -28,9 +34,11 @@ private constructor(
     val embeddingsList =
       embeddings.embedDocuments(texts, chunkSize = null, requestConfig = requestConfig)
     texts.zip(embeddingsList) { text, embedding ->
-      atomically {
-        documents.modify { it + text }
-        precomputedEmbeddings.insert(text, embedding)
+      state.getAndUpdate { prevState ->
+        State(
+          documents = prevState.documents + text,
+          prevState.precomputedEmbeddings + Pair(text, embedding)
+        )
       }
     }
   }
@@ -40,14 +48,14 @@ private constructor(
     return queryEmbedding?.let { similaritySearchByVector(it, limit) }.orEmpty()
   }
 
-  override suspend fun similaritySearchByVector(embedding: Embedding, limit: Int): List<String> =
-    atomically {
-        documents.read().mapNotNull { doc -> precomputedEmbeddings[doc]?.let { doc to it } }
-      }
+  override suspend fun similaritySearchByVector(embedding: Embedding, limit: Int): List<String> {
+    val state0 = state.get()
+    return state0.documents.asSequence().mapNotNull { doc -> state0.precomputedEmbeddings[doc]?.let { doc to it } }
       .map { (doc, embedding) -> doc to embedding.cosineSimilarity(embedding) }
       .sortedByDescending { (_, similarity) -> similarity }
       .take(limit)
-      .map { (document, _) -> document }
+      .map { (document, _) -> document }.toList()
+  }
 
   private fun Embedding.cosineSimilarity(other: Embedding): Double {
     val dotProduct = this.data.zip(other.data).sumOf { (a, b) -> (a * b).toDouble() }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
@@ -8,7 +8,10 @@ import com.xebia.functional.xef.llm.openai.EmbeddingModel
 import com.xebia.functional.xef.llm.openai.RequestConfig
 import kotlin.math.sqrt
 
-private data class State(val documents: List<String>, val precomputedEmbeddings: Map<String, Embedding>) {
+private data class State(
+  val documents: List<String>,
+  val precomputedEmbeddings: Map<String, Embedding>
+) {
   companion object {
     fun empty(): State = State(emptyList(), mapOf())
   }
@@ -17,10 +20,8 @@ private data class State(val documents: List<String>, val precomputedEmbeddings:
 private typealias AtomicState = Atomic<State>
 
 class LocalVectorStore
-private constructor(
-  private val embeddings: Embeddings,
-  private val state: AtomicState
-) : VectorStore {
+private constructor(private val embeddings: Embeddings, private val state: AtomicState) :
+  VectorStore {
 
   companion object {
     suspend operator fun invoke(embeddings: Embeddings) =
@@ -50,11 +51,14 @@ private constructor(
 
   override suspend fun similaritySearchByVector(embedding: Embedding, limit: Int): List<String> {
     val state0 = state.get()
-    return state0.documents.asSequence().mapNotNull { doc -> state0.precomputedEmbeddings[doc]?.let { doc to it } }
+    return state0.documents
+      .asSequence()
+      .mapNotNull { doc -> state0.precomputedEmbeddings[doc]?.let { doc to it } }
       .map { (doc, embedding) -> doc to embedding.cosineSimilarity(embedding) }
       .sortedByDescending { (_, similarity) -> similarity }
       .take(limit)
-      .map { (document, _) -> document }.toList()
+      .map { (document, _) -> document }
+      .toList()
   }
 
   private fun Embedding.cosineSimilarity(other: Embedding): Double {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ scala = "3.3.0"
 [libraries]
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
-arrow-fx-stm = { module = "io.arrow-kt:arrow-fx-stm", version.ref = "arrow" }
 open-ai = { module = "com.theokanning.openai-gpt3-java:service", version.ref = "openai" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-json" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref="kotlinx-coroutines" }


### PR DESCRIPTION
Following ![this ticket](https://app.clickup.com/t/861mwhxfm), in this PR we are deleting `Arrow SML` in favor of `Atomic` + `State`, which is a product (data class) with the `LocalVectorStore` state, i.e.: `documents` and `precomputedEmbeddings`