### PR TITLE
Local-Vector-Stores / addStores: make one update.

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
@@ -35,8 +35,8 @@ private constructor(private val embeddings: Embeddings, private val state: Atomi
     val embeddingsList =
       embeddings.embedDocuments(texts, chunkSize = null, requestConfig = requestConfig)
     state.getAndUpdate { prevState ->
-      val newEmbeddings = prevState.precomputedEmbeddings ++ texts.zip(embeddingsList)
-      State(prevState.documents ++ texts, newEmbeddings)
+      val newEmbeddings = prevState.precomputedEmbeddings + texts.zip(embeddingsList)
+      State(prevState.documents + texts, newEmbeddings)
     }
   }
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/vectorstores/LocalVectorStore.kt
@@ -34,13 +34,9 @@ private constructor(private val embeddings: Embeddings, private val state: Atomi
   override suspend fun addTexts(texts: List<String>) {
     val embeddingsList =
       embeddings.embedDocuments(texts, chunkSize = null, requestConfig = requestConfig)
-    texts.zip(embeddingsList) { text, embedding ->
-      state.getAndUpdate { prevState ->
-        State(
-          documents = prevState.documents + text,
-          prevState.precomputedEmbeddings + Pair(text, embedding)
-        )
-      }
+    state.getAndUpdate { prevState ->
+      val newEmbeddings = prevState.precomputedEmbeddings ++ texts.zip(embeddingsList)
+      State(prevState.documents ++ texts, newEmbeddings)
     }
   }
 


### PR DESCRIPTION
Instead of having a sequence of updates to the Atomic State, it may be more efficient to have a single bulk update. It would also be more transactional.