### PR TITLE
Rename Core's AIScope to CoreAIScope

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AI.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AI.kt
@@ -18,16 +18,16 @@ import kotlin.time.ExperimentalTime
 
 /**
  * An [AI] value represents an action relying on artificial intelligence that can be run to produce
- * an `A`. This value is _lazy_ and can be combined with other `AI` values using [AIScope.invoke],
- * and thus forms a monadic DSL.
+ * an `A`. This value is _lazy_ and can be combined with other `AI` values using
+ * [CoreAIScope.invoke], and thus forms a monadic DSL.
  *
- * All [AI] actions that are composed together using [AIScope.invoke] share the same [VectorStore],
- * [OpenAIEmbeddings] and [AIClient] instances.
+ * All [AI] actions that are composed together using [CoreAIScope.invoke] share the same
+ * [VectorStore], [OpenAIEmbeddings] and [AIClient] instances.
  */
-typealias AI<A> = suspend AIScope.() -> A
+typealias AI<A> = suspend CoreAIScope.() -> A
 
 /** A DSL block that makes it more convenient to construct [AI] values. */
-inline fun <A> ai(noinline block: suspend AIScope.() -> A): AI<A> = block
+inline fun <A> ai(noinline block: suspend CoreAIScope.() -> A): AI<A> = block
 
 /**
  * Run the [AI] value to produce an [A], this method initialises all the dependencies required to
@@ -50,14 +50,14 @@ suspend fun <A> AIScope(runtime: AIRuntime<A>, block: AI<A>, orElse: suspend (AI
 @OptIn(ExperimentalTime::class)
 suspend fun <A> MockAIScope(
   mockClient: MockOpenAIClient,
-  block: suspend AIScope.() -> A,
+  block: suspend CoreAIScope.() -> A,
   orElse: suspend (AIError) -> A
 ): A =
   try {
     val embeddings = OpenAIEmbeddings(OpenAIConfig(), mockClient)
     val vectorStore = LocalVectorStore(embeddings)
     val scope =
-      AIScope(
+      CoreAIScope(
         LLMModel.GPT_3_5_TURBO,
         LLMModel.GPT_3_5_TURBO_FUNCTIONS,
         mockClient,

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AIRuntime.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AIRuntime.kt
@@ -18,7 +18,7 @@ data class AIRuntime<A>(val runtime: suspend (block: AI<A>) -> A) {
         val embeddings = OpenAIEmbeddings(openAIConfig, openAiClient)
         val vectorStore = LocalVectorStore(embeddings)
         val scope =
-          AIScope(
+          CoreAIScope(
             defaultModel = LLMModel.GPT_3_5_TURBO_16K,
             defaultSerializationModel = LLMModel.GPT_3_5_TURBO_FUNCTIONS,
             AIClient = openAiClient,

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
@@ -20,10 +20,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.jvm.JvmName
 
 /**
- * The [AIScope] is the context in which [AI] values are run. It encapsulates all the dependencies
- * required to run [AI] values, and provides convenient syntax for writing [AI] based programs.
+ * The [CoreAIScope] is the context in which [AI] values are run. It encapsulates all the
+ * dependencies required to run [AI] values, and provides convenient syntax for writing [AI] based
+ * programs.
  */
-class AIScope(
+class CoreAIScope(
   val defaultModel: LLMModel,
   val defaultSerializationModel: LLMModel,
   val AIClient: AIClient,
@@ -40,7 +41,7 @@ class AIScope(
 ) {
 
   /**
-   * Allows invoking [AI] values in the context of this [AIScope].
+   * Allows invoking [AI] values in the context of this [CoreAIScope].
    *
    * ```kotlin
    * data class CovidNews(val title: String, val content: String)
@@ -72,7 +73,7 @@ class AIScope(
    * }
    * ```
    */
-  @AiDsl @JvmName("invokeAI") suspend operator fun <A> AI<A>.invoke(): A = invoke(this@AIScope)
+  @AiDsl @JvmName("invokeAI") suspend operator fun <A> AI<A>.invoke(): A = invoke(this@CoreAIScope)
 
   @AiDsl
   suspend fun extendContext(vararg docs: String) {
@@ -88,12 +89,12 @@ class AIScope(
    */
   @AiDsl
   suspend fun <A> contextScope(store: VectorStore, block: AI<A>): A =
-    AIScope(
+    CoreAIScope(
         defaultModel,
         defaultSerializationModel,
-        this@AIScope.AIClient,
-        CombinedVectorStore(store, this@AIScope.context),
-        this@AIScope.embeddings,
+        this@CoreAIScope.AIClient,
+        CombinedVectorStore(store, this@CoreAIScope.context),
+        this@CoreAIScope.embeddings,
       )
       .block()
 
@@ -138,7 +139,7 @@ class AIScope(
     }
   }
 
-  suspend fun <A> AIScope.tryDeserialize(
+  suspend fun <A> CoreAIScope.tryDeserialize(
     serializer: (json: String) -> A,
     maxDeserializationAttempts: Int,
     agent: AI<List<String>>
@@ -466,7 +467,7 @@ class AIScope(
     } + 3
 
   /**
-   * Run a [prompt] describes the images you want to generate within the context of [AIScope].
+   * Run a [prompt] describes the images you want to generate within the context of [CoreAIScope].
    * Returns a [ImagesGenerationResponse] containing time and urls with images generated.
    *
    * @param prompt a [Prompt] describing the images you want to generate.
@@ -482,7 +483,7 @@ class AIScope(
   ): ImagesGenerationResponse = images(Prompt(prompt), user, numberImages, size, bringFromContext)
 
   /**
-   * Run a [prompt] describes the images you want to generate within the context of [AIScope].
+   * Run a [prompt] describes the images you want to generate within the context of [CoreAIScope].
    * Returns a [ImagesGenerationResponse] containing time and urls with images generated.
    *
    * @param prompt a [Prompt] describing the images you want to generate.

--- a/integrations/sql/src/main/kotlin/com/xebia/functional/xef/sql/SQL.kt
+++ b/integrations/sql/src/main/kotlin/com/xebia/functional/xef/sql/SQL.kt
@@ -1,6 +1,6 @@
 package com.xebia.functional.xef.sql
 
-import com.xebia.functional.xef.auto.AIScope
+import com.xebia.functional.xef.auto.CoreAIScope
 import com.xebia.functional.xef.auto.AiDsl
 import com.xebia.functional.xef.sql.jdbc.JdbcConfig
 import com.xebia.functional.xef.textsplitters.TokenTextSplitter
@@ -24,26 +24,26 @@ interface SQL {
    * Generates SQL from the DDL and input prompt
    */
   @AiDsl
-  suspend fun AIScope.sql(ddl: String, input: String): List<String>
+  suspend fun CoreAIScope.sql(ddl: String, input: String): List<String>
 
   /**
    * Chooses a subset of tables from the list of [tableNames] based on the [prompt]
    */
   @AiDsl
-  suspend fun AIScope.selectTablesForPrompt(tableNames: String, prompt: String): List<String>
+  suspend fun CoreAIScope.selectTablesForPrompt(tableNames: String, prompt: String): List<String>
 
   /**
    * Returns a list of documents found in the database for the given [prompt]
    */
   @AiDsl
-  suspend fun AIScope.promptQuery(prompt: String): List<String>
+  suspend fun CoreAIScope.promptQuery(prompt: String): List<String>
 
   /**
    * Returns a recommendation of prompts that are interesting for the database
    * based on the internal ddl schema
    */
   @AiDsl
-  suspend fun AIScope.getInterestingPromptsForDatabase(): List<String>
+  suspend fun CoreAIScope.getInterestingPromptsForDatabase(): List<String>
 
 }
 
@@ -53,7 +53,7 @@ private class JDBCSQLImpl(
 
   val logger = KotlinLogging.logger {}
 
-  override suspend fun AIScope.promptQuery(
+  override suspend fun CoreAIScope.promptQuery(
     prompt: String,
   ): List<String> {
     val tableNames = getTableNames().joinToString("\n")
@@ -66,7 +66,7 @@ private class JDBCSQLImpl(
     return documentsForQuery(prompt, sql)
   }
 
-  override suspend fun AIScope.selectTablesForPrompt(
+  override suspend fun CoreAIScope.selectTablesForPrompt(
     tableNames: String, prompt: String
   ): List<String> = promptMessage(
     """|You are an AI assistant which selects the best tables from which the `goal` can be accomplished.
@@ -101,7 +101,7 @@ private class JDBCSQLImpl(
     }
   }
 
-  override suspend fun AIScope.sql(ddl: String, input: String): List<String> = promptMessage(
+  override suspend fun CoreAIScope.sql(ddl: String, input: String): List<String> = promptMessage(
     """|
        |You are an AI assistant which produces SQL SELECT queries in SQL format.
        |You only reply in valid SQL SELECT queries.
@@ -126,7 +126,7 @@ private class JDBCSQLImpl(
     """.trimMargin()
   )
 
-  override suspend fun AIScope.getInterestingPromptsForDatabase(): List<String> = promptMessage(
+  override suspend fun CoreAIScope.getInterestingPromptsForDatabase(): List<String> = promptMessage(
     """|You are an AI assistant which replies with a list of the best prompts based on the content of this database:
        |Instructions:
        |1. Select from this `ddl` 3 top prompts that the user could ask about this database

--- a/kotlin/src/commonMain/kotlin/com/xebia/functional/xef/auto/AIScope.kt
+++ b/kotlin/src/commonMain/kotlin/com/xebia/functional/xef/auto/AIScope.kt
@@ -1,0 +1,3 @@
+package com.xebia.functional.xef.auto
+
+typealias AIScope = CoreAIScope

--- a/scala/src/main/scala/com/xebia/functional/xef/scala/auto/AIScope.scala
+++ b/scala/src/main/scala/com/xebia/functional/xef/scala/auto/AIScope.scala
@@ -1,6 +1,6 @@
 package com.xebia.functional.xef.scala.auto
 
-import com.xebia.functional.xef.auto.AIScope as KtAIScope
+import com.xebia.functional.xef.auto.CoreAIScope as KtAIScope
 
 final case class AIScope(kt: KtAIScope)
 private object AIScope:


### PR DESCRIPTION
This PR renames `AIScope` to `CoreAIScope` from `xef-core`. The goal is to have a distinct name for the `AIScope` defined in `xef-core`, such that all languages can expose `AIScope` in the same package if they want.

On Scala, and Java composition over inheritance will be preferred to expose Scala and Java APIs. In Kotlin we can simply leverage extension functions, and a `typealias AIScope`.