### PR TITLE
Refactor aiClient to be camelCase

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AIRuntime.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AIRuntime.kt
@@ -21,7 +21,7 @@ data class AIRuntime<A>(val runtime: suspend (block: AI<A>) -> A) {
           CoreAIScope(
             defaultModel = LLMModel.GPT_3_5_TURBO_16K,
             defaultSerializationModel = LLMModel.GPT_3_5_TURBO_FUNCTIONS,
-            AIClient = openAiClient,
+            aiClient = openAiClient,
             context = vectorStore,
             embeddings = embeddings
           )

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
@@ -27,7 +27,7 @@ import kotlin.jvm.JvmName
 class CoreAIScope(
   val defaultModel: LLMModel,
   val defaultSerializationModel: LLMModel,
-  val AIClient: AIClient,
+  val aiClient: AIClient,
   val context: VectorStore,
   val embeddings: Embeddings,
   val maxDeserializationAttempts: Int = 3,
@@ -93,7 +93,7 @@ class CoreAIScope(
     CoreAIScope(
         defaultModel,
         defaultSerializationModel,
-        this@CoreAIScope.AIClient,
+        this@CoreAIScope.aiClient,
         CombinedVectorStore(store, this@CoreAIScope.context),
         this@CoreAIScope.embeddings,
       )
@@ -278,11 +278,11 @@ class CoreAIScope(
 
     return when (model.kind) {
       LLMModel.Kind.Completion ->
-        AIClient.createCompletion(buildCompletionRequest()).choices.map { it.text }
+        aiClient.createCompletion(buildCompletionRequest()).choices.map { it.text }
       LLMModel.Kind.Chat ->
-        AIClient.createChatCompletion(buildChatRequest()).choices.map { it.message.content }
+        aiClient.createChatCompletion(buildChatRequest()).choices.map { it.message.content }
       LLMModel.Kind.ChatWithFunctions ->
-        AIClient.createChatCompletionWithFunctions(chatWithFunctionsRequest()).choices.map {
+        aiClient.createChatCompletionWithFunctions(chatWithFunctionsRequest()).choices.map {
           it.message.functionCall.arguments
         }
     }
@@ -410,6 +410,6 @@ class CoreAIScope(
         size = size,
         user = user
       )
-    return AIClient.createImages(request)
+    return aiClient.createImages(request)
   }
 }


### PR DESCRIPTION
Tiny PR to update `AIClient` property to follow Kotlin styling using camelCase.