### PR TITLE
Delegate Cosine Similarity to OpenAI-Kotlin

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -64,10 +64,9 @@ kotlin {
     val commonMain by getting {
       dependencies {
         api(libs.bundles.arrow)
-
         api(libs.bundles.ktor.client)
         api(projects.xefTokenizer)
-
+        implementation(libs.openai.client)
         implementation(libs.uuid)
         implementation(libs.klogging)
       }


### PR DESCRIPTION
The OpenAI-Kotlin library https://github.com/aallam/openai-kotlin implements the cosine similarity feature for "embeddings", so we could delegate to it. However the API is experimental and we would need to couple to it in the `core`.