### PR TITLE
Remove publish plugin for xef-kotlin module

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
   alias(libs.plugins.kotlinx.serialization)
   alias(libs.plugins.spotless)
   alias(libs.plugins.dokka)
-  alias(libs.plugins.arrow.gradle.publish)
   alias(libs.plugins.semver.gradle)
 }
 
@@ -83,8 +82,4 @@ tasks {
       }
     }
   }
-}
-
-tasks.withType<AbstractPublishToMaven> {
-  dependsOn(tasks.withType<Sign>())
 }


### PR DESCRIPTION
The `xef-kotlin` module is not ready yet, preventing other modules from publishing in Maven. The reason is that the task for generating the metadata file fails as the module doesn't contain code.

This pull request disables the publish plugin temporarily.