### PR TITLE
Move `ai` block to xef-kotlin module

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AI.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AI.kt
@@ -11,6 +11,3 @@ import com.xebia.functional.xef.vectorstores.VectorStore
  * [VectorStore], [OpenAIEmbeddings] and [AIClient] instances.
  */
 typealias AI<A> = suspend CoreAIScope.() -> A
-
-/** A DSL block that makes it more convenient to construct [AI] values. */
-inline fun <A> ai(noinline block: suspend CoreAIScope.() -> A): AI<A> = block

--- a/gpt4all-kotlin/src/jvmMain/kotlin/com/xebia/functional/gpt4all/Gpt4AllRuntime.kt
+++ b/gpt4all-kotlin/src/jvmMain/kotlin/com/xebia/functional/gpt4all/Gpt4AllRuntime.kt
@@ -1,12 +1,9 @@
 package com.xebia.functional.gpt4all
 
 import arrow.core.Either
-import arrow.core.left
-import arrow.core.right
 import com.xebia.functional.xef.AIError
 import com.xebia.functional.xef.auto.AI
 import com.xebia.functional.xef.auto.CoreAIScope
-import com.xebia.functional.xef.auto.ai
 
 /**
  * Run the [AI] value to produce an [A], this method initialises all the dependencies required to
@@ -38,7 +35,7 @@ suspend inline fun <reified A> AI<A>.getOrThrow(): A = getOrElse { throw it }
  * @see getOrElse for an operator that allow directly handling the [AIError] case.
  */
 suspend inline fun <reified A> AI<A>.toEither(): Either<AIError, A> =
-  ai { invoke().right() }.getOrElse { it.left() }
+  Either.catchOrThrow { getOrThrow() }
 
 suspend fun <A> AIScope(block: AI<A>, orElse: suspend (AIError) -> A): A =
   try {

--- a/kotlin/src/commonMain/kotlin/com/xebia/functional/xef/auto/DSLExtensions.kt
+++ b/kotlin/src/commonMain/kotlin/com/xebia/functional/xef/auto/DSLExtensions.kt
@@ -1,0 +1,4 @@
+package com.xebia.functional.xef.auto
+
+/** A DSL block that makes it more convenient to construct [AI] values. */
+inline fun <A> ai(noinline block: suspend CoreAIScope.() -> A): AI<A> = block

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIRuntime.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIRuntime.kt
@@ -3,14 +3,10 @@
 package com.xebia.functional.xef.auto.llm.openai
 
 import arrow.core.Either
-import arrow.core.left
-import arrow.core.right
 import com.xebia.functional.xef.AIError
 import com.xebia.functional.xef.auto.AI
 import com.xebia.functional.xef.auto.CoreAIScope
-import com.xebia.functional.xef.auto.ai
 import kotlin.jvm.JvmName
-import kotlin.time.ExperimentalTime
 
 /**
  * Run the [AI] value to produce an [A], this method initialises all the dependencies required to
@@ -42,9 +38,8 @@ suspend inline fun <reified A> AI<A>.getOrThrow(): A = getOrElse { throw it }
  * @see getOrElse for an operator that allow directly handling the [AIError] case.
  */
 suspend inline fun <reified A> AI<A>.toEither(): Either<AIError, A> =
-  ai { invoke().right() }.getOrElse { it.left() }
+  Either.catchOrThrow { getOrThrow() }
 
-@OptIn(ExperimentalTime::class)
 suspend fun <A> AIScope(block: AI<A>, orElse: suspend (AIError) -> A): A =
   try {
     val scope = CoreAIScope(OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING))


### PR DESCRIPTION
This PR includes the following changes and removes the need to merge #224 

- In the file `AI.kt`:
  - Removed the `AI` type alias declaration.
  - Removed the inline function `ai`.

- In the file `Gpt4AllRuntime.kt`:
  - Removed unused imports.
  - Updated the implementation of the `toEither` function to use the `Either.catchOrThrow` operator instead of the `ai` function.
  - Removed the unused import and the `ai` function.

- Added a new file `DSLExtensions.kt` to the `kotlin/src/commonMain/kotlin/com/xebia/functional/xef/auto` directory, which contains:
  - A new inline function `ai` that provides a DSL block for constructing `AI` values.

- In the file `OpenAIRuntime.kt`:
  - Removed unused imports.
  - Updated the implementation of the `toEither` function to use the `Either.catchOrThrow` operator instead of the `ai` function.
  - Removed the `@OptIn(ExperimentalTime::class)` annotation.