### PR TITLE
Set up publishing configuration for Java

### DIFF
--- a/buildSrc/src/main/kotlin/JavaPublishingConventionsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JavaPublishingConventionsPlugin.kt
@@ -11,16 +11,8 @@ import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
 import org.gradle.plugins.signing.SigningExtension
 
-class ScalaPublishingConventionsPlugin : Plugin<Project> {
+class JavaPublishingConventionsPlugin : Plugin<Project> {
   override fun apply(project: Project): Unit = project.run {
-    val scaladocJarTask: TaskProvider<Jar> = tasks.register<Jar>("scaladocJar") {
-      group = BasePlugin.BUILD_GROUP
-      tasks.findByName("scaladoc")?.let { dependsOn(it) }
-        ?: errorMessage("The scaladoc task was not found. The Javadoc jar file won't contain any documentation")
-      archiveClassifier.set("javadoc")
-      from("$buildDir/docs/scaladoc")
-    }
-
     val publishingExtension: PublishingExtension =
       extensions.findByType<PublishingExtension>()
         ?: throw IllegalStateException("The Maven Publish plugin is required to publish the build artifacts")
@@ -36,11 +28,8 @@ class ScalaPublishingConventionsPlugin : Plugin<Project> {
     publishingExtension.run {
       publications {
         register<MavenPublication>("maven") {
-          val scala3Suffix = "_3"
-
-          artifactId = basePluginExtension.archivesName.get() + scala3Suffix
           from(components["java"])
-          artifact(scaladocJarTask)
+          pomConfiguration(project)
         }
       }
     }

--- a/buildSrc/src/main/kotlin/Predef.kt
+++ b/buildSrc/src/main/kotlin/Predef.kt
@@ -1,4 +1,5 @@
 import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPublication
 
 internal fun Project.configValue(propertyName: String, environmentVariableName: String): String? {
   val property: String? = project.properties[propertyName]?.toString()
@@ -12,6 +13,34 @@ internal fun Project.configValue(propertyName: String, environmentVariableName: 
         "$propertyName Gradle property and " +
           "$environmentVariableName environment variable are missing",
       )
+    }
+  }
+}
+
+internal fun MavenPublication.pomConfiguration(project: Project) {
+  pom {
+    name.set(project.properties["pom.name"]?.toString())
+    description.set(project.properties["pom.description"]?.toString())
+    url.set(project.properties["pom.url"]?.toString())
+
+    licenses {
+      license {
+        name.set(project.properties["pom.license.name"]?.toString())
+        url.set(project.properties["pom.license.url"]?.toString())
+      }
+    }
+
+    developers {
+      developer {
+        id.set(project.properties["pom.developer.id"].toString())
+        name.set(project.properties["pom.developer.name"].toString())
+      }
+    }
+
+    scm {
+      url.set(project.properties["pom.smc.url"].toString())
+      connection.set(project.properties["pom.smc.connection"].toString())
+      developerConnection.set(project.properties["pom.smc.developerConnection"].toString())
     }
   }
 }

--- a/buildSrc/src/main/kotlin/xef-java-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/xef-java-publishing-conventions.gradle.kts
@@ -1,0 +1,1 @@
+apply<JavaPublishingConventionsPlugin>()

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -2,6 +2,9 @@
 
 plugins {
     `java-library`
+    `maven-publish`
+    signing
+    `xef-java-publishing-conventions`
     alias(libs.plugins.semver.gradle)
     alias(libs.plugins.spotless)
 }
@@ -16,6 +19,15 @@ dependencies {
     api(libs.jakarta.validation)
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 tasks.withType<Test>().configureEach {
     useJUnit()
+}
+
+tasks.withType<AbstractPublishToMaven> {
+    dependsOn(tasks.withType<Sign>())
 }


### PR DESCRIPTION
This pull request sets up the required Gradle configuration to publish the new Java module to Maven. The `arrow-gradle-config` plugin doesn't support Java modules, so we created a custom plugin for the publishing conventions.