### PR TITLE
Exclude Java examples module in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Assemble
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assemble -x:kotlin-loom:assemble -x:xef-scala:assemble -x:xef-scala-examples:assemble
+          arguments: assemble -x:kotlin-loom:assemble -x:xef-java-examples:assemble -x:xef-scala:assemble -x:xef-scala-examples:assemble
 
       - name: Upload reports
         if: failure()


### PR DESCRIPTION
The `publish` job is failing because the `xef-java-examples` module requires Java 17, but that job uses version 11. This pull request excludes this module from the `assemble` task to avoid the mentioned failure.