### PR TITLE
implementation of CoreAIScope as Autocloseable

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AutoClose.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AutoClose.kt
@@ -1,0 +1,39 @@
+package com.xebia.functional.xef.auto
+
+import arrow.atomic.Atomic
+import arrow.atomic.update
+
+/**
+ * AutoClose offers DSL style API for creating parent-child relationships of AutoCloseable dependencies
+ */
+interface AutoClose : AutoCloseable {
+  fun <A : AutoCloseable> autoClose(autoCloseable: A): A
+}
+
+/** DSL method to use AutoClose */
+fun <A> autoClose(block: AutoClose.() -> A): A =
+  AutoClose().use(block)
+
+/**
+ * Constructor for AutoClose to be use for interface delegation of already scoped classes.
+ */
+fun AutoClose(): AutoClose =
+  object : AutoClose {
+    private val finalizers: Atomic<List<() -> Unit>> = Atomic(emptyList())
+
+    fun <A : AutoCloseable> autoClose(autoCloseable: A): A {
+      finalizers.update { prev -> prev + autoCloseable::close }
+      return autoCloseable
+    }
+
+    fun close() {
+      finalizers.get().fold<() -> Unit, Throwable?>(null) { acc, function ->
+        acc.add(runCatching { function.invoke() }.exceptionOrNull())
+      }?.let { throw it }
+    }
+  }
+
+private fun Throwable?.add(other: Throwable?): Throwable? =
+  this?.apply {
+    other?.let { addSuppressed(it) }
+  } ?: other

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AutoClose.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/AutoClose.kt
@@ -8,8 +8,17 @@ import arrow.atomic.update
  */
 interface AutoClose : AutoCloseable {
   fun <A : AutoCloseable> autoClose(autoCloseable: A): A
+}
 
-  companion object : AutoClose {
+/** DSL method to use AutoClose */
+fun <A> autoClose(block: AutoClose.() -> A): A =
+  autoClose().use(block)
+
+/**
+ * Constructor for AutoClose to be use for interface delegation of already scoped classes.
+ */
+fun autoClose(): AutoClose =
+  object : AutoClose {
     private val finalizers: Atomic<List<() -> Unit>> = Atomic(emptyList())
 
     override fun <A : AutoCloseable> autoClose(autoCloseable: A): A {
@@ -23,11 +32,6 @@ interface AutoClose : AutoCloseable {
       }?.let { throw it }
     }
   }
-}
-
-/** DSL method to use AutoClose */
-fun <A> autoClose(block: AutoClose.() -> A): A =
-  AutoClose.use(block)
 
 private fun Throwable?.add(other: Throwable?): Throwable? =
   this?.apply {

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
@@ -29,7 +29,7 @@ constructor(
   val embeddings: Embeddings,
   val context: VectorStore = LocalVectorStore(embeddings),
   val conversationId: ConversationId = ConversationId(UUID.generateUUID().toString())
-) : AutoCloseable, AutoClose by AutoClose() {
+) : AutoCloseable, AutoClose by AutoClose {
 
   /**
    * Allows invoking [AI] values in the context of this [CoreAIScope].

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
@@ -29,7 +29,7 @@ constructor(
   val embeddings: Embeddings,
   val context: VectorStore = LocalVectorStore(embeddings),
   val conversationId: ConversationId = ConversationId(UUID.generateUUID().toString())
-) : AutoCloseable, AutoClose by AutoClose {
+) : AutoCloseable, AutoClose by autoClose() {
 
   /**
    * Allows invoking [AI] values in the context of this [CoreAIScope].

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/CoreAIScope.kt
@@ -1,7 +1,6 @@
 package com.xebia.functional.xef.auto
 
-import arrow.atomic.Atomic
-import arrow.atomic.update
+import com.xebia.functional.xef.auto.AutoClose
 import com.xebia.functional.xef.AIError
 import com.xebia.functional.xef.embeddings.Embeddings
 import com.xebia.functional.xef.llm.Chat
@@ -29,8 +28,8 @@ class CoreAIScope
 constructor(
   val embeddings: Embeddings,
   val context: VectorStore = LocalVectorStore(embeddings),
-  val conversationId: ConversationId = ConversationId(UUID.generateUUID().toString()),
-) : AutoCloseable {
+  val conversationId: ConversationId = ConversationId(UUID.generateUUID().toString())
+) : AutoCloseable, AutoClose by AutoClose() {
 
   /**
    * Allows invoking [AI] values in the context of this [CoreAIScope].
@@ -161,22 +160,4 @@ constructor(
     size: String = "1024x1024",
     promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS
   ): ImagesGenerationResponse = images(prompt, context, numberImages, size, promptConfiguration)
-
-  private val finalizers: Atomic<List<() -> Unit>> = Atomic(emptyList())
-
-  fun <A : AutoCloseable> autoClose(autoCloseable: A): A {
-    finalizers.update { prev -> prev + autoCloseable::close }
-    return autoCloseable
-  }
-
-  override fun close() {
-    finalizers.get().fold<() -> Unit, Throwable?>(null) { acc, function ->
-      acc.add(runCatching { function.invoke() }.exceptionOrNull())
-    }?.let { throw it }
-  }
-
-  private fun Throwable?.add(other: Throwable?): Throwable? =
-    this?.apply {
-      other?.let { addSuppressed(it) }
-    } ?: other
 }

--- a/gpt4all-kotlin/src/jvmMain/kotlin/com/xebia/functional/gpt4all/Gpt4AllRuntime.kt
+++ b/gpt4all-kotlin/src/jvmMain/kotlin/com/xebia/functional/gpt4all/Gpt4AllRuntime.kt
@@ -39,9 +39,9 @@ suspend inline fun <A> AI<A>.toEither(): Either<AIError, A> =
 
 suspend fun <A> AIScope(block: AI<A>, orElse: suspend (AIError) -> A): A =
   try {
-    val scope = CoreAIScope(HuggingFaceLocalEmbeddings.DEFAULT)
-    block(scope)
+    CoreAIScope(HuggingFaceLocalEmbeddings.DEFAULT).use {
+      block(it)
+    }
   } catch (e: AIError) {
     orElse(e)
   }
-

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIRuntime.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIRuntime.kt
@@ -41,8 +41,9 @@ suspend inline fun <A> AI<A>.toEither(): Either<AIError, A> = Either.catchOrThro
 
 suspend fun <A> AIScope(block: AI<A>, orElse: suspend (AIError) -> A): A =
   try {
-    val scope = CoreAIScope(OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING))
-    block(scope)
+    CoreAIScope(OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)).use {
+      block(it)
+    }
   } catch (e: AIError) {
     orElse(e)
   }


### PR DESCRIPTION
Little PR that adds an implementation of `CoreAIScope` as `AutoCloseable`. This implementation is based on @nomisRev implementation of the `AutoClose` DSL (see [here](https://gist.github.com/nomisRev/952c619fa40c7c0041974992a6ad1e06)). This way, we can add dependencies and resources with the `autoClose` function so that they will be automatically closed once the scope is closed.