### PR TITLE
#861n30d7t: Making OpenAI AutoCloseable and AutoClose

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -1,4 +1,4 @@
-# xef.ai for Scala
+# xef.ai for Java
 
 Build the project locally, from the project root:
 

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
@@ -3,39 +3,43 @@ package com.xebia.functional.xef.auto.llm.openai
 import arrow.core.nonEmptyListOf
 import com.xebia.functional.tokenizer.ModelType
 import com.xebia.functional.xef.AIError
+import com.xebia.functional.xef.auto.AutoClose
+import com.xebia.functional.xef.auto.autoClose
 import com.xebia.functional.xef.env.getenv
 import kotlin.jvm.JvmField
 
-class OpenAI(internal val token: String) {
-  val GPT_4 = OpenAIModel(this, "gpt-4", ModelType.GPT_4)
+class OpenAI(internal val token: String) : AutoCloseable, AutoClose by autoClose() {
+  val GPT_4 by lazy { autoClose(OpenAIModel(this, "gpt-4", ModelType.GPT_4)) }
 
-  val GPT_4_0314 = OpenAIModel(this, "gpt-4-0314", ModelType.GPT_4)
+  val GPT_4_0314 by lazy { autoClose(OpenAIModel(this, "gpt-4-0314", ModelType.GPT_4)) }
 
-  val GPT_4_32K = OpenAIModel(this, "gpt-4-32k", ModelType.GPT_4_32K)
+  val GPT_4_32K by lazy { autoClose(OpenAIModel(this, "gpt-4-32k", ModelType.GPT_4_32K)) }
 
-  val GPT_3_5_TURBO = OpenAIModel(this, "gpt-3.5-turbo", ModelType.GPT_3_5_TURBO)
+  val GPT_3_5_TURBO by lazy { autoClose(OpenAIModel(this, "gpt-3.5-turbo", ModelType.GPT_3_5_TURBO)) }
 
-  val GPT_3_5_TURBO_16K = OpenAIModel(this, "gpt-3.5-turbo-16k", ModelType.GPT_3_5_TURBO_16_K)
+  val GPT_3_5_TURBO_16K by lazy { autoClose(OpenAIModel(this, "gpt-3.5-turbo-16k", ModelType.GPT_3_5_TURBO_16_K)) }
 
-  val GPT_3_5_TURBO_FUNCTIONS =
-    OpenAIModel(this, "gpt-3.5-turbo-0613", ModelType.GPT_3_5_TURBO_FUNCTIONS)
+  val GPT_3_5_TURBO_FUNCTIONS by lazy {
+    autoClose(OpenAIModel(this, "gpt-3.5-turbo-0613", ModelType.GPT_3_5_TURBO_FUNCTIONS))
+  }
 
-  val GPT_3_5_TURBO_0301 = OpenAIModel(this, "gpt-3.5-turbo-0301", ModelType.GPT_3_5_TURBO)
+  val GPT_3_5_TURBO_0301 by lazy { autoClose(OpenAIModel(this, "gpt-3.5-turbo-0301", ModelType.GPT_3_5_TURBO)) }
 
-  val TEXT_DAVINCI_003 = OpenAIModel(this, "text-davinci-003", ModelType.TEXT_DAVINCI_003)
+  val TEXT_DAVINCI_003 by lazy { autoClose(OpenAIModel(this, "text-davinci-003", ModelType.TEXT_DAVINCI_003)) }
 
-  val TEXT_DAVINCI_002 = OpenAIModel(this, "text-davinci-002", ModelType.TEXT_DAVINCI_002)
+  val TEXT_DAVINCI_002 by lazy { autoClose(OpenAIModel(this, "text-davinci-002", ModelType.TEXT_DAVINCI_002)) }
 
-  val TEXT_CURIE_001 = OpenAIModel(this, "text-curie-001", ModelType.TEXT_SIMILARITY_CURIE_001)
+  val TEXT_CURIE_001 by lazy { autoClose(OpenAIModel(this, "text-curie-001", ModelType.TEXT_SIMILARITY_CURIE_001)) }
 
-  val TEXT_BABBAGE_001 = OpenAIModel(this, "text-babbage-001", ModelType.TEXT_BABBAGE_001)
+  val TEXT_BABBAGE_001 by lazy { autoClose(OpenAIModel(this, "text-babbage-001", ModelType.TEXT_BABBAGE_001)) }
 
-  val TEXT_ADA_001 = OpenAIModel(this, "text-ada-001", ModelType.TEXT_ADA_001)
+  val TEXT_ADA_001 by lazy { autoClose(OpenAIModel(this, "text-ada-001", ModelType.TEXT_ADA_001)) }
 
-  val TEXT_EMBEDDING_ADA_002 =
-    OpenAIModel(this, "text-embedding-ada-002", ModelType.TEXT_EMBEDDING_ADA_002)
+  val TEXT_EMBEDDING_ADA_002 by lazy {
+    autoClose(OpenAIModel(this, "text-embedding-ada-002", ModelType.TEXT_EMBEDDING_ADA_002))
+  }
 
-  val DALLE_2 = OpenAIModel(this, "dalle-2", ModelType.GPT_3_5_TURBO)
+  val DALLE_2 by lazy { autoClose(OpenAIModel(this, "dalle-2", ModelType.GPT_3_5_TURBO)) }
 
   companion object {
 
@@ -43,6 +47,8 @@ class OpenAI(internal val token: String) {
       return getenv("OPENAI_TOKEN")
         ?: throw AIError.Env.OpenAI(nonEmptyListOf("missing OPENAI_TOKEN env var"))
     }
+
+    // TODO: Handle the lifetime of these values!
 
     @JvmField val DEFAULT = OpenAI(openAITokenFromEnv())
 

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
@@ -48,8 +48,6 @@ class OpenAI(internal val token: String) : AutoCloseable, AutoClose by autoClose
         ?: throw AIError.Env.OpenAI(nonEmptyListOf("missing OPENAI_TOKEN env var"))
     }
 
-    // TODO: Handle the lifetime of these values!
-
     @JvmField val DEFAULT = OpenAI(openAITokenFromEnv())
 
     @JvmField val DEFAULT_CHAT = DEFAULT.GPT_3_5_TURBO_16K


### PR DESCRIPTION
Work towards better handling the lifetime of classes and the resources they need. In this case, this PR implements the `OpenAI` class (that provides a number of LLM to be easily consumed by users) as `AutoCloseable` and `AutoClose`, making sure that all `OpenAIClient`s are closed when we are no longer using the model.