### PR TITLE
Fixing Add memories with functions

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
@@ -236,7 +236,12 @@ interface Chat : LLM {
         Memory(
           conversationId = conversationId,
           content =
-            Message(role = role, content = firstChoice.message?.content ?: "", name = role.name),
+            Message(
+              role = role,
+              content = firstChoice.message?.content
+                  ?: firstChoice.message?.functionCall?.arguments ?: "",
+              name = role.name
+            ), //
           timestamp = getTimeMillis()
         )
       context.addMemories(listOf(requestMemory, firstChoiceMemory))


### PR DESCRIPTION
When we add memories on `ChatCompletionRequestWithFunctions` the `content` is empty and should use `functionCall?.arguments`. This `arguments` contains the JSON string response from `OpenAI`. 

This is important because using conversations if we have `ASSISTANTS` messages with empty content, `OpenAI` mix the last `USER` messages given random responses.