### PR TITLE
Add static apply method to enable creating RequestConfig from Scala

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/embeddings/RequestConfig.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/embeddings/RequestConfig.kt
@@ -1,9 +1,14 @@
 package com.xebia.functional.xef.llm.models.embeddings
 
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmStatic
 
 data class RequestConfig(val model: EmbeddingModel, val user: User) {
   companion object {
+    @JvmStatic
+    fun apply(model: EmbeddingModel, userId: String): RequestConfig {
+      return RequestConfig(model, User(userId))
+    }
     @JvmInline value class User(val id: String)
   }
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/embeddings/RequestConfig.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/embeddings/RequestConfig.kt
@@ -9,6 +9,7 @@ data class RequestConfig(val model: EmbeddingModel, val user: User) {
     fun apply(model: EmbeddingModel, userId: String): RequestConfig {
       return RequestConfig(model, User(userId))
     }
+
     @JvmInline value class User(val id: String)
   }
 }

--- a/scala/src/test/scala/com/xebia/functional/xef/llm/models/embeddings/RequestConfigSpec.scala
+++ b/scala/src/test/scala/com/xebia/functional/xef/llm/models/embeddings/RequestConfigSpec.scala
@@ -1,0 +1,14 @@
+package com.xebia.functional.xef.llm.models.embeddings
+
+import munit.FunSuite
+
+
+class RequestConfigSpec extends FunSuite:
+
+  test("Should create a RequestConfig through the static apply method") {
+    val requestConfig = RequestConfig(EmbeddingModel.TEXT_EMBEDDING_ADA_002, "user")
+
+    assertEquals(requestConfig.getModel, EmbeddingModel.TEXT_EMBEDDING_ADA_002)
+  }
+
+

--- a/scala/src/test/scala/com/xebia/functional/xef/llm/models/embeddings/RequestConfigSpec.scala
+++ b/scala/src/test/scala/com/xebia/functional/xef/llm/models/embeddings/RequestConfigSpec.scala
@@ -2,7 +2,6 @@ package com.xebia.functional.xef.llm.models.embeddings
 
 import munit.FunSuite
 
-
 class RequestConfigSpec extends FunSuite:
 
   test("Should create a RequestConfig through the static apply method") {
@@ -10,5 +9,3 @@ class RequestConfigSpec extends FunSuite:
 
     assertEquals(requestConfig.getModel, EmbeddingModel.TEXT_EMBEDDING_ADA_002)
   }
-
-


### PR DESCRIPTION
With the factory, it should be possible to create `RequestConfig` instances from Scala and Java.

This seems necessary because `User` is an inline value class. See #275

I'm not sure if it also makes sense to add a String getter for user.