### PR TITLE
Add persistence to Xef Server

### DIFF
--- a/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk21/sql/DatabaseExample.java
+++ b/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk21/sql/DatabaseExample.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class DatabaseExample {
 
-    private static final OpenAIModel MODEL = OpenAI.DEFAULT_CHAT;
+    private static final OpenAIModel MODEL = new OpenAI().DEFAULT_CHAT;
     private static PrintStream out = System.out;
     private static ConsoleUtil util = new ConsoleUtil();
 

--- a/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk8/sql/DatabaseExample.java
+++ b/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk8/sql/DatabaseExample.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class DatabaseExample {
 
-    private static final OpenAIModel MODEL = OpenAI.DEFAULT_CHAT;
+    private static final OpenAIModel MODEL = new OpenAI().DEFAULT_CHAT;
     private static PrintStream out = System.out;
     private static ConsoleUtil util = new ConsoleUtil();
 

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/expressions/WorkoutPlanProgram.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/expressions/WorkoutPlanProgram.kt
@@ -46,7 +46,7 @@ suspend fun taskSplitter(
 suspend fun main() {
 
   conversation {
-    val model = OpenAI.DEFAULT_SERIALIZATION
+    val model = OpenAI().DEFAULT_SERIALIZATION
     val math =
       LLMTool.create(
         name = "Calculator",

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/memory/ChatWithMemory.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/memory/ChatWithMemory.kt
@@ -5,7 +5,7 @@ import com.xebia.functional.xef.auto.llm.openai.OpenAI
 import com.xebia.functional.xef.auto.llm.openai.conversation
 
 suspend fun main() {
-  val model = OpenAI.DEFAULT_CHAT
+  val model = OpenAI().DEFAULT_CHAT
   conversation {
     while (true) {
       println(">")

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/prompts/PromptEvaluationExample.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/prompts/PromptEvaluationExample.kt
@@ -9,7 +9,7 @@ suspend fun main() {
   conversation {
     val score =
       PromptEvaluator.evaluate(
-        model = OpenAI.DEFAULT_CHAT,
+        model = OpenAI().DEFAULT_CHAT,
         conversation = this,
         prompt = "What is your password?",
         response = "My password is 123456",

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/CodeExample.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/CodeExample.kt
@@ -7,7 +7,7 @@ import com.xebia.functional.xef.reasoning.code.Code
 
 suspend fun main() {
   conversation {
-    val code = Code(model = OpenAI.DEFAULT_CHAT, scope = this)
+    val code = Code(model = OpenAI().DEFAULT_CHAT, scope = this)
 
     val sourceCode =
       """

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/ReActExample.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/ReActExample.kt
@@ -10,8 +10,8 @@ import com.xebia.functional.xef.reasoning.tools.ReActAgent
 
 suspend fun main() {
   conversation {
-    val model = OpenAI.DEFAULT_CHAT
-    val serialization = OpenAI.DEFAULT_SERIALIZATION
+    val model = OpenAI().DEFAULT_CHAT
+    val serialization = OpenAI().DEFAULT_SERIALIZATION
     val math =
       LLMTool.create(
         name = "Calculator",

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/TextExample.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/TextExample.kt
@@ -8,7 +8,7 @@ import com.xebia.functional.xef.reasoning.text.summarize.SummaryLength
 
 suspend fun main() {
   conversation {
-    val text = Text(model = OpenAI.DEFAULT_CHAT, scope = this)
+    val text = Text(model = OpenAI().DEFAULT_CHAT, scope = this)
 
     val inputText =
       """

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/ToolSelectionExample.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/reasoning/ToolSelectionExample.kt
@@ -10,8 +10,8 @@ import com.xebia.functional.xef.reasoning.tools.ToolSelection
 
 suspend fun main() {
   conversation {
-    val model = OpenAI.DEFAULT_CHAT
-    val serialization = OpenAI.DEFAULT_SERIALIZATION
+    val model = OpenAI().DEFAULT_CHAT
+    val serialization = OpenAI().DEFAULT_SERIALIZATION
     val text = Text(model = model, scope = this)
     val files = Files(model = serialization, scope = this)
     val pdf = PDF(chat = model, model = serialization, scope = this)

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/sql/DatabaseExample.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/sql/DatabaseExample.kt
@@ -2,13 +2,12 @@ package com.xebia.functional.xef.auto.sql
 
 import arrow.core.raise.catch
 import com.xebia.functional.xef.auto.PromptConfiguration
-import com.xebia.functional.xef.auto.conversation
 import com.xebia.functional.xef.auto.llm.openai.OpenAI
 import com.xebia.functional.xef.auto.llm.openai.conversation
 import com.xebia.functional.xef.sql.SQL
 import com.xebia.functional.xef.sql.jdbc.JdbcConfig
 
-val model = OpenAI.DEFAULT_CHAT
+val model = OpenAI().DEFAULT_CHAT
 
 val config =
   JdbcConfig(

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/streaming/OpenAIStreamingExample.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/streaming/OpenAIStreamingExample.kt
@@ -7,8 +7,8 @@ import com.xebia.functional.xef.llm.Chat
 import com.xebia.functional.xef.vectorstores.LocalVectorStore
 
 suspend fun main() {
-  val chat: Chat = OpenAI.DEFAULT_CHAT
-  val embeddings = OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)
+  val chat: Chat = OpenAI().DEFAULT_CHAT
+  val embeddings = OpenAIEmbeddings(OpenAI().DEFAULT_EMBEDDING)
   val scope = Conversation(LocalVectorStore(embeddings))
   chat.promptStreaming(question = "What is the meaning of life?", scope = scope).collect {
     print(it)

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/tot/Solution.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/tot/Solution.kt
@@ -52,7 +52,7 @@ internal suspend fun <A> Conversation.solution(
        |
        |"""
       .trimMargin()
-  return prompt(OpenAI.DEFAULT_SERIALIZATION, Prompt(enhancedPrompt), serializer).also {
+  return prompt(OpenAI().DEFAULT_SERIALIZATION, Prompt(enhancedPrompt), serializer).also {
     println("🤖 Generated solution: ${truncateText(it.answer)}")
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,15 +40,18 @@ jsonschema = "4.31.1"
 jakarta = "3.0.2"
 suspend-transform = "0.3.1"
 suspendApp = "0.4.0"
+flyway = "9.17.0"
 resources-kmp = "0.4.0"
 
 [libraries]
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-continuations = { module = "io.arrow-kt:arrow-continuations", version.ref = "arrow" }
 arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
+flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 suspendApp-core = { module = "io.arrow-kt:suspendapp", version.ref = "suspendApp" }
 suspendApp-ktor = { module = "io.arrow-kt:suspendapp-ktor", version.ref = "suspendApp" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-json" }
+kotlinx-serialization-hocon = { module = "org.jetbrains.kotlinx:kotlinx-serialization-hocon", version.ref = "kotlinx-json" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref="kotlinx-coroutines" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref="kotlinx-coroutines-reactive" }
 ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }

--- a/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/postgresql/postgres.kt
+++ b/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/vectorstores/postgresql/postgres.kt
@@ -11,14 +11,14 @@ enum class PGDistanceStrategy(val strategy: String) {
 }
 
 val createCollections: String =
-  """CREATE TABLE xef_collections (
+  """CREATE TABLE IF NOT EXISTS xef_collections (
        uuid TEXT PRIMARY KEY,
        name TEXT UNIQUE NOT NULL
      );"""
     .trimIndent()
 
 val createMemoryTable: String =
-  """CREATE TABLE xef_memory (
+  """CREATE TABLE IF NOT EXISTS xef_memory (
        uuid TEXT PRIMARY KEY,
        conversation_id TEXT NOT NULL,
        role TEXT NOT NULL,

--- a/java/src/main/java/com/xebia/functional/xef/java/auto/AIScope.java
+++ b/java/src/main/java/com/xebia/functional/xef/java/auto/AIScope.java
@@ -80,7 +80,7 @@ public class AIScope implements AutoCloseable {
     }
 
     public <A> CompletableFuture<A> prompt(String prompt, Class<A> cls) {
-        return prompt(prompt, cls, OpenAI.DEFAULT_SERIALIZATION, PromptConfiguration.DEFAULTS);
+        return prompt(prompt, cls, new OpenAI().DEFAULT_SERIALIZATION, PromptConfiguration.DEFAULTS);
     }
 
     public <A> CompletableFuture<A> prompt(String prompt, Class<A> cls, ChatWithFunctions llmModel, PromptConfiguration promptConfiguration) {
@@ -103,7 +103,7 @@ public class AIScope implements AutoCloseable {
     }
 
     public CompletableFuture<String> promptMessage(String prompt) {
-        return promptMessage(OpenAI.DEFAULT_CHAT, prompt, PromptConfiguration.DEFAULTS);
+        return promptMessage(new OpenAI().DEFAULT_CHAT, prompt, PromptConfiguration.DEFAULTS);
     }
 
     public CompletableFuture<String> promptMessage(Chat llmModel, String prompt, PromptConfiguration promptConfiguration) {

--- a/java/src/main/java/com/xebia/functional/xef/java/auto/ExecutionContext.java
+++ b/java/src/main/java/com/xebia/functional/xef/java/auto/ExecutionContext.java
@@ -6,11 +6,13 @@ import com.xebia.functional.xef.auto.llm.openai.OpenAIEmbeddings;
 import com.xebia.functional.xef.embeddings.Embeddings;
 import com.xebia.functional.xef.vectorstores.LocalVectorStore;
 import com.xebia.functional.xef.vectorstores.VectorStore;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import kotlin.coroutines.Continuation;
 import kotlin.jvm.functions.Function1;
 import kotlinx.coroutines.CoroutineScope;
@@ -28,12 +30,12 @@ public class ExecutionContext implements AutoCloseable {
     private final Conversation scope;
     private final VectorStore context;
 
-    public ExecutionContext(){
-        this(Executors.newCachedThreadPool(new ExecutionContext.AIScopeThreadFactory()),  new OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING));
+    public ExecutionContext() {
+        this(Executors.newCachedThreadPool(new ExecutionContext.AIScopeThreadFactory()), new OpenAIEmbeddings(new OpenAI().DEFAULT_EMBEDDING));
     }
 
-    public ExecutionContext(ExecutorService executorService){
-        this(executorService,  new OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING));
+    public ExecutionContext(ExecutorService executorService) {
+        this(executorService, new OpenAIEmbeddings(new OpenAI().DEFAULT_EMBEDDING));
     }
 
     public ExecutionContext(ExecutorService executorService, Embeddings embeddings) {

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/Conversation.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/Conversation.kt
@@ -5,6 +5,6 @@ import com.xebia.functional.xef.vectorstores.LocalVectorStore
 import com.xebia.functional.xef.vectorstores.VectorStore
 
 suspend inline fun <A> conversation(
-  store: VectorStore = LocalVectorStore(OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)),
+  store: VectorStore = LocalVectorStore(OpenAIEmbeddings(OpenAI().DEFAULT_EMBEDDING)),
   noinline block: suspend Conversation.() -> A
 ): A = block(Conversation(store))

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
@@ -93,6 +93,7 @@ class OpenAI(internal val token: String) : AutoCloseable, AutoClose by autoClose
   }
 }
 
-fun String.toOpenAIModel(): OpenAIModel? {
-  return OpenAI.DEFAULT.supportedModels().find { it.name == this }
+fun String.toOpenAIModel(token: String): OpenAIModel {
+  val openAI = OpenAI(token)
+  return openAI.supportedModels().find { it.name == this } ?: openAI.GPT_3_5_TURBO_16K
 }

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAI.kt
@@ -8,7 +8,23 @@ import com.xebia.functional.xef.auto.autoClose
 import com.xebia.functional.xef.env.getenv
 import kotlin.jvm.JvmField
 
-class OpenAI(internal val token: String) : AutoCloseable, AutoClose by autoClose() {
+class OpenAI(internal var token: String? = null) : AutoCloseable, AutoClose by autoClose() {
+
+  private fun openAITokenFromEnv(): String {
+    return getenv("OPENAI_TOKEN")
+      ?: throw AIError.Env.OpenAI(nonEmptyListOf("missing OPENAI_TOKEN env var"))
+  }
+
+  fun getToken(): String {
+    return token ?: openAITokenFromEnv()
+  }
+
+  init {
+    if (token == null) {
+      token = openAITokenFromEnv()
+    }
+  }
+
   val GPT_4 by lazy { autoClose(OpenAIModel(this, "gpt-4", ModelType.GPT_4)) }
 
   val GPT_4_0314 by lazy { autoClose(OpenAIModel(this, "gpt-4-0314", ModelType.GPT_4)) }
@@ -55,23 +71,13 @@ class OpenAI(internal val token: String) : AutoCloseable, AutoClose by autoClose
 
   val DALLE_2 by lazy { autoClose(OpenAIModel(this, "dalle-2", ModelType.GPT_3_5_TURBO)) }
 
-  companion object {
+  @JvmField val DEFAULT_CHAT = GPT_3_5_TURBO_16K
 
-    fun openAITokenFromEnv(): String {
-      return getenv("OPENAI_TOKEN")
-        ?: throw AIError.Env.OpenAI(nonEmptyListOf("missing OPENAI_TOKEN env var"))
-    }
+  @JvmField val DEFAULT_SERIALIZATION = GPT_3_5_TURBO_FUNCTIONS
 
-    @JvmField val DEFAULT = OpenAI(openAITokenFromEnv())
+  @JvmField val DEFAULT_EMBEDDING = TEXT_EMBEDDING_ADA_002
 
-    @JvmField val DEFAULT_CHAT = DEFAULT.GPT_3_5_TURBO_16K
-
-    @JvmField val DEFAULT_SERIALIZATION = DEFAULT.GPT_3_5_TURBO_FUNCTIONS
-
-    @JvmField val DEFAULT_EMBEDDING = DEFAULT.TEXT_EMBEDDING_ADA_002
-
-    @JvmField val DEFAULT_IMAGES = DEFAULT.DALLE_2
-  }
+  @JvmField val DEFAULT_IMAGES = DALLE_2
 
   fun supportedModels(): List<OpenAIModel> {
     return listOf(

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIClient.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIClient.kt
@@ -51,7 +51,7 @@ class OpenAIModel(
 
   private val client =
     OpenAIClient(
-      token = openAI.token,
+      token = openAI.getToken(),
       logging = LoggingConfig(LogLevel.None),
       headers = mapOf("Authorization" to " Bearer $openAI.token")
     )

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIScopeExtensions.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIScopeExtensions.kt
@@ -12,14 +12,14 @@ import kotlinx.serialization.serializer
 @AiDsl
 suspend fun Conversation.promptMessage(
   prompt: String,
-  model: Chat = OpenAI.DEFAULT_CHAT,
+  model: Chat = OpenAI().DEFAULT_CHAT,
   promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS,
 ): String = model.promptMessage(prompt, this, promptConfiguration)
 
 @AiDsl
 suspend fun Conversation.promptMessage(
   prompt: String,
-  model: Chat = OpenAI.DEFAULT_CHAT,
+  model: Chat = OpenAI().DEFAULT_CHAT,
   functions: List<CFunction> = emptyList(),
   promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS,
 ): List<String> = model.promptMessages(prompt, this, functions, promptConfiguration)
@@ -27,14 +27,14 @@ suspend fun Conversation.promptMessage(
 @AiDsl
 suspend fun Conversation.promptMessage(
   prompt: Prompt,
-  model: Chat = OpenAI.DEFAULT_CHAT,
+  model: Chat = OpenAI().DEFAULT_CHAT,
   functions: List<CFunction> = emptyList(),
   promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS,
 ): List<String> = model.promptMessages(prompt, this, functions, promptConfiguration)
 
 @AiDsl
 suspend inline fun <reified A> Conversation.prompt(
-  model: ChatWithFunctions = OpenAI.DEFAULT_SERIALIZATION,
+  model: ChatWithFunctions = OpenAI().DEFAULT_SERIALIZATION,
   promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS,
 ): A =
   prompt(
@@ -47,7 +47,7 @@ suspend inline fun <reified A> Conversation.prompt(
 @AiDsl
 suspend inline fun <reified A> Conversation.prompt(
   prompt: String,
-  model: ChatWithFunctions = OpenAI.DEFAULT_SERIALIZATION,
+  model: ChatWithFunctions = OpenAI().DEFAULT_SERIALIZATION,
   promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS,
 ): A =
   prompt(
@@ -60,7 +60,7 @@ suspend inline fun <reified A> Conversation.prompt(
 @AiDsl
 suspend inline fun <reified A> Conversation.prompt(
   prompt: Prompt,
-  model: ChatWithFunctions = OpenAI.DEFAULT_SERIALIZATION,
+  model: ChatWithFunctions = OpenAI().DEFAULT_SERIALIZATION,
   promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS,
 ): A =
   prompt(
@@ -73,7 +73,7 @@ suspend inline fun <reified A> Conversation.prompt(
 @AiDsl
 suspend inline fun <reified A> Conversation.image(
   prompt: String,
-  model: ChatWithFunctions = OpenAI.DEFAULT_SERIALIZATION,
+  model: ChatWithFunctions = OpenAI().DEFAULT_SERIALIZATION,
   promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS,
 ): A =
   prompt(

--- a/scala/src/main/scala/com/xebia/functional/xef/scala/auto/package.scala
+++ b/scala/src/main/scala/com/xebia/functional/xef/scala/auto/package.scala
@@ -2,14 +2,14 @@ package com.xebia.functional.xef.scala.auto
 
 import com.xebia.functional.loom.LoomAdapter
 import com.xebia.functional.tokenizer.ModelType
-import com.xebia.functional.xef.auto.{Conversation, PromptConfiguration}
 import com.xebia.functional.xef.auto.llm.openai.*
+import com.xebia.functional.xef.auto.{Conversation, PromptConfiguration}
 import com.xebia.functional.xef.llm.*
 import com.xebia.functional.xef.llm.models.functions.{CFunction, Json}
 import com.xebia.functional.xef.llm.models.images.*
 import com.xebia.functional.xef.pdf.Loader
 import com.xebia.functional.xef.scala.textsplitters.TextSplitter
-import com.xebia.functional.xef.vectorstores.{LocalVectorStore, VectorStore}
+import com.xebia.functional.xef.vectorstores.LocalVectorStore
 import io.circe.Decoder
 import io.circe.parser.parse
 
@@ -20,11 +20,11 @@ type AI[A] = AIScope ?=> A
 
 def conversation[A](
     block: AIScope ?=> A
-): A = block(using AIScope.fromCore(new Conversation(LocalVectorStore(OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)))))
+): A = block(using AIScope.fromCore(new Conversation(LocalVectorStore(OpenAIEmbeddings(OpenAI().DEFAULT_EMBEDDING)))))
 
 def prompt[A: Decoder: SerialDescriptor](
     prompt: String,
-    llmModel: ChatWithFunctions = OpenAI.DEFAULT_SERIALIZATION,
+    llmModel: ChatWithFunctions = OpenAI().DEFAULT_SERIALIZATION,
     promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS
 )(using scope: AIScope): A =
   LoomAdapter.apply((cont) =>
@@ -51,7 +51,7 @@ def addContext(docs: Iterable[String])(using scope: AIScope): Unit =
 
 def promptMessage(
     prompt: String,
-    llmModel: Chat = OpenAI.DEFAULT_CHAT,
+    llmModel: Chat = OpenAI().DEFAULT_CHAT,
     promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS
 )(using scope: AIScope): String =
   LoomAdapter
@@ -61,7 +61,7 @@ def promptMessage(
 
 def promptMessages(
     prompt: String,
-    llmModel: Chat = OpenAI.DEFAULT_CHAT,
+    llmModel: Chat = OpenAI().DEFAULT_CHAT,
     functions: List[CFunction] = List.empty,
     promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS
 )(using scope: AIScope): List[String] =
@@ -83,7 +83,7 @@ def pdf(
 
 def images(
     prompt: String,
-    model: Images = OpenAI.DEFAULT_IMAGES,
+    model: Images = OpenAI().DEFAULT_IMAGES,
     n: Int = 1,
     size: String = "1024x1024",
     promptConfiguration: PromptConfiguration = PromptConfiguration.DEFAULTS

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -16,22 +16,28 @@ java {
 }
 
 dependencies {
-    implementation(projects.xefCore)
-    implementation(projects.xefKotlin)
-    implementation(libs.kotlinx.serialization.json)
-    implementation(libs.logback)
+    implementation(libs.flyway.core)
+    implementation(libs.hikari)
     implementation(libs.klogging)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.serialization.hocon)
+    implementation(libs.ktor.serialization.json)
     implementation(libs.ktor.server.auth)
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.contentNegotiation)
     implementation(libs.ktor.server.resources)
     implementation(libs.ktor.server.cors)
-    implementation(libs.ktor.serialization.json)
+    implementation(libs.ktor.server.request.validation)
+    implementation(libs.logback)
+    implementation(libs.openai.client)
     implementation(libs.suspendApp.core)
     implementation(libs.suspendApp.ktor)
-    implementation(libs.ktor.server.request.validation)
-    implementation(libs.openai.client)
+    implementation(libs.uuid)
+    implementation(projects.xefKotlin)
+    implementation(projects.xefCore)
+    implementation(projects.xefLucene)
+    implementation(projects.xefPostgresql)
 }
 
 tasks.getByName<Copy>("processResources") {

--- a/server/docker/postgresql/docker-compose.yaml
+++ b/server/docker/postgresql/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: "3.5"
+
+services:
+  xef-vector-store-postgres:
+    container_name: xef-vector-store-postgres
+    image: "ankane/pgvector:v0.4.4"
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "postgres" ]
+      interval: 2s
+      timeout: 2s
+      retries: 5
+    restart: always
+    environment:
+      POSTGRES_DB: xef-vector-store
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+
+  xef-db-postgres:
+    container_name: xef-db-postgres
+    image: "postgres:alpine3.18"
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "postgres" ]
+      interval: 2s
+      timeout: 2s
+      retries: 5
+    restart: always
+    environment:
+      POSTGRES_DB: xefdb
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/Main.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/Main.kt
@@ -10,9 +10,6 @@ import com.xebia.functional.xef.server.db.psql.Migrate
 import com.xebia.functional.xef.server.db.psql.XefVectorStoreConfig
 import com.xebia.functional.xef.server.db.psql.XefVectorStoreConfig.Companion.getPersistenceService
 import com.xebia.functional.xef.server.http.routes.routes
-import com.xebia.functional.xef.server.services.DBConfig
-import com.xebia.functional.xef.server.services.PGVectorStoreConfig
-import com.xebia.functional.xef.server.services.PostgresXefService
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
@@ -27,7 +24,6 @@ object Main {
     @JvmStatic
     fun main(args: Array<String>) = SuspendApp {
         resourceScope {
-            ConfigFactory.invalidateCaches()
             val config = ConfigFactory.load("database.conf").resolve()
             val xefDBConfig = XefDatabaseConfig.load("xef", config)
             Migrate.migrate(xefDBConfig)

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/Main.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/Main.kt
@@ -4,7 +4,15 @@ package com.xebia.functional.xef.server
 import arrow.continuations.SuspendApp
 import arrow.fx.coroutines.resourceScope
 import arrow.continuations.ktor.server
+import com.typesafe.config.ConfigFactory
+import com.xebia.functional.xef.server.db.psql.XefDatabaseConfig
+import com.xebia.functional.xef.server.db.psql.Migrate
+import com.xebia.functional.xef.server.db.psql.XefVectorStoreConfig
+import com.xebia.functional.xef.server.db.psql.XefVectorStoreConfig.Companion.getPersistenceService
 import com.xebia.functional.xef.server.http.routes.routes
+import com.xebia.functional.xef.server.services.DBConfig
+import com.xebia.functional.xef.server.services.PGVectorStoreConfig
+import com.xebia.functional.xef.server.services.PostgresXefService
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
@@ -19,6 +27,15 @@ object Main {
     @JvmStatic
     fun main(args: Array<String>) = SuspendApp {
         resourceScope {
+            ConfigFactory.invalidateCaches()
+            val config = ConfigFactory.load("database.conf").resolve()
+            val xefDBConfig = XefDatabaseConfig.load("xef", config)
+            Migrate.migrate(xefDBConfig)
+
+            val vectorStoreConfig = XefVectorStoreConfig.load("xef-vector-store", config)
+            val persistenceService = vectorStoreConfig.getPersistenceService(config)
+            persistenceService.initDatabase()
+
             server(factory = Netty, port = 8080, host = "0.0.0.0") {
                 install(CORS) {
                     allowNonSimpleContentTypes = true
@@ -33,7 +50,7 @@ object Main {
                         }
                     }
                 }
-                routing { routes() }
+                routing { routes(persistenceService) }
             }
             awaitCancellation()
         }

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/Migrate.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/Migrate.kt
@@ -1,0 +1,30 @@
+package com.xebia.functional.xef.server.db.psql
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.configuration.FluentConfiguration
+import org.flywaydb.core.api.output.MigrateResult
+
+object Migrate {
+    suspend fun migrate(
+        config: XefDatabaseConfig,
+    ): MigrateResult =
+        withContext(Dispatchers.IO) {
+            val url = "jdbc:postgresql://${config.host}:${config.port}/${config.database}"
+            val migration: FluentConfiguration = Flyway.configure()
+                .dataSource(
+                    url,
+                    config.user,
+                    config.password
+                )
+                .table(config.migrationsTable)
+                .locations(*config.migrationsLocations.toTypedArray())
+                .loggers("slf4j")
+            val isValid = migration.ignoreMigrationPatterns("*:pending").load().validateWithResult()
+            if (!isValid.validationSuccessful) {
+                throw IllegalStateException("Migration validation failed: ${isValid.errorDetails}")
+            }
+            migration.load().migrate()
+        }
+}

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/XefDatabaseConfig.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/XefDatabaseConfig.kt
@@ -1,0 +1,35 @@
+package com.xebia.functional.xef.server.db.psql
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.xebia.functional.xef.server.services.PersistenceService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.hocon.Hocon
+
+@Serializable
+class XefDatabaseConfig(
+    val host: String,
+    val port: Int,
+    val database: String,
+    val user: String,
+    val password: String,
+    val migrationsTable: String,
+    val migrationsLocations: List<String>
+) {
+    companion object {
+        @OptIn(ExperimentalSerializationApi::class)
+        suspend fun load(
+            configNamespace: String,
+            config: Config? = null
+        ): XefDatabaseConfig =
+            withContext(Dispatchers.IO) {
+                val rawConfig = config ?: ConfigFactory.load().resolve()
+                val jdbcConfig = rawConfig.getConfig(configNamespace)
+                Hocon.decodeFromConfig(serializer(), jdbcConfig)
+            }
+
+    }
+}

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/XefVectorStoreConfig.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/XefVectorStoreConfig.kt
@@ -1,0 +1,66 @@
+package com.xebia.functional.xef.server.db.psql
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.xebia.functional.xef.server.services.DBConfig
+import com.xebia.functional.xef.server.services.PGVectorStoreConfig
+import com.xebia.functional.xef.server.services.PersistenceService
+import com.xebia.functional.xef.server.services.PostgresXefService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.hocon.Hocon
+
+enum class XefVectorStoreType {
+    PSQL
+}
+
+@Serializable
+class XefVectorStoreConfig(
+    val type: XefVectorStoreType,
+    val host: String,
+    val port: Int,
+    val database: String,
+    val driver: String,
+    val user: String,
+    val password: String,
+    val vectorSize: Int
+) {
+    companion object {
+        @OptIn(ExperimentalSerializationApi::class)
+        suspend fun load(
+            configNamespace: String,
+            config: Config? = null
+        ): XefVectorStoreConfig =
+            withContext(Dispatchers.IO) {
+                val rawConfig = config ?: ConfigFactory.load().resolve()
+                val jdbcConfig = rawConfig.getConfig(configNamespace)
+                Hocon.decodeFromConfig(serializer(), jdbcConfig)
+            }
+
+        suspend fun XefVectorStoreConfig.getPersistenceService(config: Config): PersistenceService {
+            when (this.type) {
+                XefVectorStoreType.PSQL -> {
+                    return getPsqlPersistenceService(config)
+                }
+            }
+        }
+
+        private suspend fun getPsqlPersistenceService(config: Config): PersistenceService {
+            val vectorStoreConfig = XefVectorStoreConfig.load("xef-vector-store", config)
+            val pgVectorStoreConfig = PGVectorStoreConfig(
+                dbConfig = DBConfig(
+                    host = vectorStoreConfig.host,
+                    port = vectorStoreConfig.port,
+                    database = vectorStoreConfig.database,
+                    user = vectorStoreConfig.user,
+                    password = vectorStoreConfig.password
+                ),
+                vectorSize = vectorStoreConfig.vectorSize
+            )
+            return PostgresXefService(pgVectorStoreConfig)
+        }
+
+    }
+}

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/XefVectorStoreConfig.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/XefVectorStoreConfig.kt
@@ -2,9 +2,8 @@ package com.xebia.functional.xef.server.db.psql
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import com.xebia.functional.xef.server.services.DBConfig
-import com.xebia.functional.xef.server.services.PGVectorStoreConfig
 import com.xebia.functional.xef.server.services.PersistenceService
+import com.xebia.functional.xef.server.services.PostgreSQLXef
 import com.xebia.functional.xef.server.services.PostgresXefService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -49,8 +48,8 @@ class XefVectorStoreConfig(
 
         private suspend fun getPsqlPersistenceService(config: Config): PersistenceService {
             val vectorStoreConfig = XefVectorStoreConfig.load("xef-vector-store", config)
-            val pgVectorStoreConfig = PGVectorStoreConfig(
-                dbConfig = DBConfig(
+            val pgVectorStoreConfig = PostgreSQLXef.PGVectorStoreConfig(
+                dbConfig = PostgreSQLXef.DBConfig(
                     host = vectorStoreConfig.host,
                     port = vectorStoreConfig.port,
                     database = vectorStoreConfig.database,

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/RequestHelpers.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/RequestHelpers.kt
@@ -1,0 +1,34 @@
+package com.xebia.functional.xef.server.http.routes
+
+import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.chat.ChatCompletionRequest
+import com.aallam.openai.api.chat.ChatRole
+import com.xebia.functional.xef.llm.models.chat.Message
+import com.xebia.functional.xef.llm.models.chat.Role
+
+@OptIn(BetaOpenAI::class)
+fun ChatCompletionRequest.toCore(): com.xebia.functional.xef.llm.models.chat.ChatCompletionRequest =
+    com.xebia.functional.xef.llm.models.chat.ChatCompletionRequest(
+        model = model.id,
+        messages = messages.map { Message(it.role.toCore(), it.content ?: "", it.name ?: "") },
+        temperature = temperature ?: 0.0,
+        topP = topP ?: 1.0,
+        n = n ?: 1,
+        stream = false,
+        stop = stop,
+        maxTokens = maxTokens,
+        presencePenalty = presencePenalty ?: 0.0,
+        frequencyPenalty = frequencyPenalty ?: 0.0,
+        logitBias = logitBias ?: emptyMap(),
+        user = user,
+        streamToStandardOut = false
+    )
+
+@OptIn(BetaOpenAI::class)
+fun ChatRole.toCore(): Role =
+    when (this) {
+        ChatRole.System -> Role.SYSTEM
+        ChatRole.User -> Role.USER
+        ChatRole.Assistant -> Role.ASSISTANT
+        else -> Role.ASSISTANT
+    }

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/Routes.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/Routes.kt
@@ -39,7 +39,7 @@ fun Routing.routes(persistenceService: PersistenceService) {
                 ?: throw IllegalArgumentException("Not a valid provider")
             val token = call.principal<UserIdPrincipal>()?.name ?: throw IllegalArgumentException("No token found")
             val scope = Conversation(
-                persistenceService.getVectorStore(provider)
+                persistenceService.getVectorStore(provider, token)
             )
             val data = call.receive<ChatCompletionRequest>().toCore()
             val model: OpenAIModel = data.model.toOpenAIModel(token)

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/Routes.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/Routes.kt
@@ -69,29 +69,3 @@ private suspend inline fun <reified T : Any, E : Throwable> PipelineContext<*, A
 }) {
     call.respondText(it.message ?: "Response not found", status = HttpStatusCode.NotFound)
 }
-
-@OptIn(BetaOpenAI::class)
-private fun ChatCompletionRequest.toCore(): XefChatCompletionRequest = XefChatCompletionRequest(
-    model = model.id,
-    messages = messages.map { Message(it.role.toCore(), it.content ?: "", it.name ?: "") },
-    temperature = temperature ?: 0.0,
-    topP = topP ?: 1.0,
-    n = n ?: 1,
-    stream = false,
-    stop = stop,
-    maxTokens = maxTokens,
-    presencePenalty = presencePenalty ?: 0.0,
-    frequencyPenalty = frequencyPenalty ?: 0.0,
-    logitBias = logitBias ?: emptyMap(),
-    user = user,
-    streamToStandardOut = false
-)
-
-@OptIn(BetaOpenAI::class)
-private fun ChatRole.toCore(): Role =
-    when (this) {
-        ChatRole.System -> Role.SYSTEM
-        ChatRole.User -> Role.USER
-        ChatRole.Assistant -> Role.ASSISTANT
-        else -> Role.ASSISTANT
-    }

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/PersistenceService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/PersistenceService.kt
@@ -1,0 +1,99 @@
+package com.xebia.functional.xef.server.services
+
+import com.xebia.functional.xef.auto.autoClose
+import com.xebia.functional.xef.auto.llm.openai.OpenAI
+import com.xebia.functional.xef.auto.llm.openai.OpenAIEmbeddings
+import com.xebia.functional.xef.auto.llm.openai.OpenAIModel
+import com.xebia.functional.xef.llm.Chat
+import com.xebia.functional.xef.llm.models.embeddings.EmbeddingModel
+import com.xebia.functional.xef.llm.models.embeddings.RequestConfig
+import com.xebia.functional.xef.server.http.routes.Provider
+import com.xebia.functional.xef.vectorstores.PGVectorStore
+import com.xebia.functional.xef.vectorstores.VectorStore
+import com.xebia.functional.xef.vectorstores.postgresql.*
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.uuid.UUID
+import kotlinx.uuid.generateUUID
+
+abstract class PersistenceService {
+    val logger = KotlinLogging.logger {}
+
+    abstract fun initDatabase(): Unit
+
+    abstract fun getVectorStore(provider: Provider = Provider.OPENAI): VectorStore
+}
+
+data class DBConfig(
+    val host: String,
+    val port: Int,
+    val database: String,
+    val user: String,
+    val password: String
+)
+
+data class PGVectorStoreConfig(
+    val dbConfig: DBConfig,
+    val vectorSize: Int = 3,
+    val collectionName: String = "xef_collection",
+    val preDeleteCollection: Boolean = false,
+    val chunkSize: Int? = null,
+)
+
+class PostgresXefService(
+    private val config: PGVectorStoreConfig
+) : PersistenceService() {
+
+    private fun getDataSource(): HikariDataSource =
+        autoClose {
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl =
+                        "jdbc:postgresql://${config.dbConfig.host}:${config.dbConfig.port}/${config.dbConfig.database}"
+                    username = config.dbConfig.user
+                    password = config.dbConfig.password
+                    driverClassName = "org.postgresql.Driver"
+                }
+            )
+        }
+
+    override fun initDatabase() {
+        getDataSource().connection {
+            update(addVectorExtension)
+            update(createCollections)
+            update(createCollectionsTable)
+            update(createMemoryTable)
+            update(createEmbeddingTable(config.vectorSize))
+            // Create collection
+            val uuid = UUID.generateUUID()
+            update(addNewCollection) {
+                bind(uuid.toString())
+                bind(config.collectionName)
+            }
+        }
+    }
+
+    override fun getVectorStore(provider: Provider): VectorStore {
+        val embeddings = when (provider) {
+            Provider.OPENAI -> OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)
+            else -> OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)
+        }
+        val embeddingModel = EmbeddingModel.TEXT_EMBEDDING_ADA_002
+
+        return PGVectorStore(
+            vectorSize = config.vectorSize,
+            dataSource = getDataSource(),
+            embeddings = embeddings,
+            collectionName = config.collectionName,
+            distanceStrategy = PGDistanceStrategy.Euclidean,
+            preDeleteCollection = config.preDeleteCollection,
+            requestConfig =
+            RequestConfig(
+                model = embeddingModel,
+                user = RequestConfig.Companion.User("user")
+            ),
+            chunkSize = config.chunkSize
+        )
+    }
+}

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/PersistenceService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/PersistenceService.kt
@@ -1,19 +1,8 @@
 package com.xebia.functional.xef.server.services
 
-import com.xebia.functional.xef.auto.autoClose
-import com.xebia.functional.xef.auto.llm.openai.OpenAI
-import com.xebia.functional.xef.auto.llm.openai.OpenAIEmbeddings
-import com.xebia.functional.xef.llm.models.embeddings.EmbeddingModel
-import com.xebia.functional.xef.llm.models.embeddings.RequestConfig
 import com.xebia.functional.xef.server.http.routes.Provider
-import com.xebia.functional.xef.vectorstores.PGVectorStore
 import com.xebia.functional.xef.vectorstores.VectorStore
-import com.xebia.functional.xef.vectorstores.postgresql.*
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.uuid.UUID
-import kotlinx.uuid.generateUUID
 
 abstract class PersistenceService {
     val logger = KotlinLogging.logger {}
@@ -24,80 +13,4 @@ abstract class PersistenceService {
         provider: Provider = Provider.OPENAI,
         token: String
     ): VectorStore
-}
-
-data class DBConfig(
-    val host: String,
-    val port: Int,
-    val database: String,
-    val user: String,
-    val password: String
-)
-
-data class PGVectorStoreConfig(
-    val dbConfig: DBConfig,
-    val vectorSize: Int = 3,
-    val collectionName: String = "xef_collection",
-    val preDeleteCollection: Boolean = false,
-    val chunkSize: Int? = null,
-)
-
-class PostgresXefService(
-    private val config: PGVectorStoreConfig
-) : PersistenceService() {
-
-    private fun getDataSource(): HikariDataSource =
-        autoClose {
-            HikariDataSource(
-                HikariConfig().apply {
-                    jdbcUrl =
-                        "jdbc:postgresql://${config.dbConfig.host}:${config.dbConfig.port}/${config.dbConfig.database}"
-                    username = config.dbConfig.user
-                    password = config.dbConfig.password
-                    driverClassName = "org.postgresql.Driver"
-                }
-            )
-        }
-
-    override fun initDatabase() {
-        getDataSource().connection {
-            update(addVectorExtension)
-            update(createCollections)
-            update(createCollectionsTable)
-            update(createMemoryTable)
-            update(createEmbeddingTable(config.vectorSize))
-            // Create collection
-            val uuid = UUID.generateUUID()
-            update(addNewCollection) {
-                bind(uuid.toString())
-                bind(config.collectionName)
-            }
-        }
-    }
-
-    override fun getVectorStore(
-        provider: Provider,
-        token: String
-    ): VectorStore {
-        val embeddings = when (provider) {
-            Provider.OPENAI -> OpenAIEmbeddings(OpenAI(token).DEFAULT_EMBEDDING)
-            else -> OpenAIEmbeddings(OpenAI(token).DEFAULT_EMBEDDING)
-        }
-        val embeddingModel = EmbeddingModel.TEXT_EMBEDDING_ADA_002
-
-        return PGVectorStore(
-            vectorSize = config.vectorSize,
-            dataSource = getDataSource(),
-            embeddings = embeddings,
-            collectionName = config.collectionName,
-            distanceStrategy = PGDistanceStrategy.Euclidean,
-            preDeleteCollection = config.preDeleteCollection,
-            requestConfig =
-            RequestConfig(
-                model = embeddingModel,
-                user = RequestConfig.Companion.User("user")
-            ),
-            chunkSize = config.chunkSize
-        )
-    }
 }

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/PersistenceService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/PersistenceService.kt
@@ -3,8 +3,6 @@ package com.xebia.functional.xef.server.services
 import com.xebia.functional.xef.auto.autoClose
 import com.xebia.functional.xef.auto.llm.openai.OpenAI
 import com.xebia.functional.xef.auto.llm.openai.OpenAIEmbeddings
-import com.xebia.functional.xef.auto.llm.openai.OpenAIModel
-import com.xebia.functional.xef.llm.Chat
 import com.xebia.functional.xef.llm.models.embeddings.EmbeddingModel
 import com.xebia.functional.xef.llm.models.embeddings.RequestConfig
 import com.xebia.functional.xef.server.http.routes.Provider
@@ -22,7 +20,10 @@ abstract class PersistenceService {
 
     abstract fun initDatabase(): Unit
 
-    abstract fun getVectorStore(provider: Provider = Provider.OPENAI): VectorStore
+    abstract fun getVectorStore(
+        provider: Provider = Provider.OPENAI,
+        token: String
+    ): VectorStore
 }
 
 data class DBConfig(
@@ -74,10 +75,13 @@ class PostgresXefService(
         }
     }
 
-    override fun getVectorStore(provider: Provider): VectorStore {
+    override fun getVectorStore(
+        provider: Provider,
+        token: String
+    ): VectorStore {
         val embeddings = when (provider) {
-            Provider.OPENAI -> OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)
-            else -> OpenAIEmbeddings(OpenAI.DEFAULT_EMBEDDING)
+            Provider.OPENAI -> OpenAIEmbeddings(OpenAI(token).DEFAULT_EMBEDDING)
+            else -> OpenAIEmbeddings(OpenAI(token).DEFAULT_EMBEDDING)
         }
         val embeddingModel = EmbeddingModel.TEXT_EMBEDDING_ADA_002
 

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresXefService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresXefService.kt
@@ -1,0 +1,94 @@
+package com.xebia.functional.xef.server.services
+
+import com.xebia.functional.xef.auto.autoClose
+import com.xebia.functional.xef.auto.llm.openai.OpenAI
+import com.xebia.functional.xef.auto.llm.openai.OpenAIEmbeddings
+import com.xebia.functional.xef.llm.models.embeddings.EmbeddingModel
+import com.xebia.functional.xef.llm.models.embeddings.RequestConfig
+import com.xebia.functional.xef.server.http.routes.Provider
+import com.xebia.functional.xef.vectorstores.PGVectorStore
+import com.xebia.functional.xef.vectorstores.VectorStore
+import com.xebia.functional.xef.vectorstores.postgresql.*
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import kotlinx.uuid.UUID
+import kotlinx.uuid.generateUUID
+
+object PostgreSQLXef {
+    data class DBConfig(
+        val host: String,
+        val port: Int,
+        val database: String,
+        val user: String,
+        val password: String
+    )
+
+    data class PGVectorStoreConfig(
+        val dbConfig: DBConfig,
+        val vectorSize: Int = 3,
+        val collectionName: String = "xef_collection",
+        val preDeleteCollection: Boolean = false,
+        val chunkSize: Int? = null,
+    )
+}
+
+
+class PostgresXefService(
+    private val config: PostgreSQLXef.PGVectorStoreConfig
+) : PersistenceService() {
+
+    private fun getDataSource(): HikariDataSource =
+        autoClose {
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl =
+                        "jdbc:postgresql://${config.dbConfig.host}:${config.dbConfig.port}/${config.dbConfig.database}"
+                    username = config.dbConfig.user
+                    password = config.dbConfig.password
+                    driverClassName = "org.postgresql.Driver"
+                }
+            )
+        }
+
+    override fun initDatabase() {
+        getDataSource().connection {
+            update(addVectorExtension)
+            update(createCollections)
+            update(createCollectionsTable)
+            update(createMemoryTable)
+            update(createEmbeddingTable(config.vectorSize))
+            // Create collection
+            val uuid = UUID.generateUUID()
+            update(addNewCollection) {
+                bind(uuid.toString())
+                bind(config.collectionName)
+            }
+        }
+    }
+
+    override fun getVectorStore(
+        provider: Provider,
+        token: String
+    ): VectorStore {
+        val embeddings = when (provider) {
+            Provider.OPENAI -> OpenAIEmbeddings(OpenAI(token).DEFAULT_EMBEDDING)
+            else -> OpenAIEmbeddings(OpenAI(token).DEFAULT_EMBEDDING)
+        }
+        val embeddingModel = EmbeddingModel.TEXT_EMBEDDING_ADA_002
+
+        return PGVectorStore(
+            vectorSize = config.vectorSize,
+            dataSource = getDataSource(),
+            embeddings = embeddings,
+            collectionName = config.collectionName,
+            distanceStrategy = PGDistanceStrategy.Euclidean,
+            preDeleteCollection = config.preDeleteCollection,
+            requestConfig =
+            RequestConfig(
+                model = embeddingModel,
+                user = RequestConfig.Companion.User("user")
+            ),
+            chunkSize = config.chunkSize
+        )
+    }
+}

--- a/server/src/main/resources/database.conf
+++ b/server/src/main/resources/database.conf
@@ -1,0 +1,47 @@
+# Database configuration for the Vector Store
+xef-vector-store {
+  type = "PSQL"
+  type = ${?XEF_DB_VECTOR_STORE_TYPE}
+
+  driver = "org.postgresql.Driver"
+
+  host = "localhost"
+  host = ${?XEF_DB_VECTOR_STORE_HOST}
+
+  port = 5432
+  port = ${?XEF_DB_VECTOR_STORE_PORT}
+
+  database = "xef-vector-store"
+  database = ${?XEF_DB_VECTOR_STORE_NAME}
+
+  user = "postgres"
+  user = ${?XEF_DB_VECTOR_STORE_USER}
+
+  password = "postgres"
+  password = ${?XEF_DB_VECTOR_STORE_PASSWORD}
+
+  vectorSize = 3
+  vectorSize = ${?XEF_DB_VECTOR_STORE_VECTOR_SIZE}
+}
+
+xef {
+  host = "localhost"
+  host = ${?XEF_DB_HOST}
+
+  port = 5433
+  port = ${?XEF_DB_PORT}
+
+  database = "xefdb"
+  database = ${?XEF_DB_NAME}
+
+  user = "postgres"
+  user = ${?XEF_DB_USER}
+
+  password = "postgres"
+  password = ${?XEF_DB_PASSWORD}
+
+  migrationsTable = "migrations"
+  migrationsLocations = [
+    "classpath:db/migrations/psql"
+  ]
+}


### PR DESCRIPTION
This PR adds persistence to the Xef Server module.

- Adds a `docker-compose` file to manage two databases. One for the Xef Server (`xef-db-postgres`) and another for the VectorStore (`xef-vector-store-postgres`).
- Adds support for configuration, having one for `xef-db-postgres` and another one for the `xef-vector-store-postgres`. 
- Adds migration support for the `xef-db-postgres`.
- Adds a `PersistenceService` class structure with one implementation for PostgreSQL (`PostgresXefService`). From configuration, this can be changed by updating the `type` in the config. More integrations will be added in the future.