### PR TITLE
Simplify access to functions and prompts

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/Conversation.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/Conversation.kt
@@ -44,9 +44,9 @@ interface Conversation : AutoClose, AutoCloseable {
   @JvmSynthetic
   suspend fun <A> ChatWithFunctions.prompt(
     prompt: Prompt,
-    functions: List<CFunction>,
+    function: CFunction,
     serializer: (String) -> A
-  ): A = prompt(prompt, conversation, functions, serializer)
+  ): A = prompt(prompt, conversation, function, serializer)
 
   @AiDsl
   @JvmSynthetic

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/Conversation.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/auto/Conversation.kt
@@ -10,10 +10,8 @@ import com.xebia.functional.xef.prompt.Prompt
 import com.xebia.functional.xef.vectorstores.ConversationId
 import com.xebia.functional.xef.vectorstores.VectorStore
 import kotlin.jvm.JvmSynthetic
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.KSerializer
 import kotlinx.uuid.UUID
 import kotlinx.uuid.generateUUID
 
@@ -31,14 +29,6 @@ interface Conversation : AutoClose, AutoCloseable {
     store.addTexts(docs.toList())
   }
 
-  fun CoroutineScope.addContextAsync(vararg docs: String): Deferred<Unit> = async {
-    store.addTexts(docs.toList())
-  }
-
-  fun CoroutineScope.addContextAsync(docs: Iterable<String>): Deferred<Unit> = async {
-    store.addTexts(docs.toList())
-  }
-
   @AiDsl
   @JvmSynthetic
   suspend fun addContext(docs: Iterable<String>): Unit {
@@ -47,47 +37,30 @@ interface Conversation : AutoClose, AutoCloseable {
 
   @AiDsl
   @JvmSynthetic
+  suspend fun <A> ChatWithFunctions.prompt(prompt: Prompt, serializer: KSerializer<A>): A =
+    prompt(prompt, conversation, serializer)
+
+  @AiDsl
+  @JvmSynthetic
   suspend fun <A> ChatWithFunctions.prompt(
     prompt: Prompt,
     functions: List<CFunction>,
-    serializer: (json: String) -> A
-  ): A = prompt(prompt, conversation, serializer, functions)
-
-  fun <A> CoroutineScope.promptAsync(
-    chatWithFunctions: ChatWithFunctions,
-    prompt: Prompt,
-    functions: List<CFunction>,
-    serializer: (json: String) -> A,
-  ): Deferred<A> = async { chatWithFunctions.prompt(prompt, conversation, serializer, functions) }
+    serializer: (String) -> A
+  ): A = prompt(prompt, conversation, functions, serializer)
 
   @AiDsl
   @JvmSynthetic
   suspend fun Chat.promptMessage(
     prompt: Prompt,
-  ): String =
-    promptMessages(prompt, conversation, emptyList()).firstOrNull() ?: throw AIError.NoResponse()
-
-  @AiDsl
-  fun CoroutineScope.promptMessageAsync(chat: Chat, prompt: Prompt): Deferred<String> = async {
-    chat.promptMessage(prompt)
-  }
+  ): String = promptMessages(prompt, conversation).firstOrNull() ?: throw AIError.NoResponse()
 
   @AiDsl
   @JvmSynthetic
-  suspend fun Chat.promptMessages(
-    prompt: Prompt,
-    functions: List<CFunction> = emptyList()
-  ): List<String> = promptMessages(prompt, conversation, functions)
-
-  fun CoroutineScope.promptMessagesAsync(
-    chat: Chat,
-    prompt: Prompt,
-    functions: List<CFunction> = emptyList()
-  ): Deferred<List<String>> = async { chat.promptMessages(prompt, conversation, functions) }
+  suspend fun Chat.promptMessages(prompt: Prompt): List<String> =
+    promptMessages(prompt, conversation)
 
   @AiDsl
-  fun Chat.promptStreaming(prompt: Prompt, functions: List<CFunction>): Flow<String> =
-    promptStreaming(prompt, conversation, functions)
+  fun Chat.promptStreaming(prompt: Prompt): Flow<String> = promptStreaming(prompt, conversation)
 
   /**
    * Run a [prompt] describes the images you want to generate within the context of [Conversation].
@@ -104,13 +77,6 @@ interface Conversation : AutoClose, AutoCloseable {
     numberImages: Int = 1,
     size: String = "1024x1024"
   ): ImagesGenerationResponse = images(prompt, store, numberImages, size)
-
-  fun CoroutineScope.imagesAsync(
-    images: Images,
-    prompt: Prompt,
-    numberImages: Int = 1,
-    size: String = "1024x1024"
-  ): Deferred<ImagesGenerationResponse> = async { images.images(prompt, store, numberImages, size) }
 
   companion object {
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
@@ -81,8 +81,8 @@ interface Chat : LLM {
         n = prompt.configuration.numberOfPredictions,
         temperature = prompt.configuration.temperature,
         maxTokens = prompt.configuration.minResponseTokens,
-        functions = prompt.functions,
-        functionCall = mapOf("name" to (prompt.functions.firstOrNull()?.name ?: ""))
+        functions = listOfNotNull(prompt.function),
+        functionCall = mapOf("name" to (prompt.function?.name ?: ""))
       )
 
     return when (this) {

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
@@ -6,7 +6,6 @@ import com.xebia.functional.xef.AIError
 import com.xebia.functional.xef.auto.AiDsl
 import com.xebia.functional.xef.auto.Conversation
 import com.xebia.functional.xef.llm.models.chat.*
-import com.xebia.functional.xef.llm.models.functions.CFunction
 import com.xebia.functional.xef.prompt.Prompt
 import com.xebia.functional.xef.prompt.configuration.PromptConfiguration
 import com.xebia.functional.xef.prompt.templates.assistant
@@ -27,11 +26,7 @@ interface Chat : LLM {
   fun tokensFromMessages(messages: List<Message>): Int
 
   @AiDsl
-  fun promptStreaming(
-    prompt: Prompt,
-    scope: Conversation,
-    functions: List<CFunction> = emptyList()
-  ): Flow<String> = flow {
+  fun promptStreaming(prompt: Prompt, scope: Conversation): Flow<String> = flow {
     val messagesForRequest =
       fitMessagesByTokens(prompt.messages, scope, modelType, prompt.configuration)
 
@@ -60,14 +55,10 @@ interface Chat : LLM {
 
   @AiDsl
   suspend fun promptMessage(prompt: Prompt, scope: Conversation): String =
-    promptMessages(prompt, scope, emptyList()).firstOrNull() ?: throw AIError.NoResponse()
+    promptMessages(prompt, scope).firstOrNull() ?: throw AIError.NoResponse()
 
   @AiDsl
-  suspend fun promptMessages(
-    prompt: Prompt,
-    scope: Conversation,
-    functions: List<CFunction> = emptyList()
-  ): List<String> {
+  suspend fun promptMessages(prompt: Prompt, scope: Conversation): List<String> {
 
     val messagesForRequest =
       fitMessagesByTokens(prompt.messages, scope, modelType, prompt.configuration)
@@ -90,8 +81,8 @@ interface Chat : LLM {
         n = prompt.configuration.numberOfPredictions,
         temperature = prompt.configuration.temperature,
         maxTokens = prompt.configuration.minResponseTokens,
-        functions = functions,
-        functionCall = mapOf("name" to (functions.firstOrNull()?.name ?: ""))
+        functions = prompt.functions,
+        functionCall = mapOf("name" to (prompt.functions.firstOrNull()?.name ?: ""))
       )
 
     return when (this) {

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
@@ -24,13 +24,13 @@ interface ChatWithFunctions : Chat {
   ): ChatCompletionResponseWithFunctions
 
   @OptIn(ExperimentalSerializationApi::class)
-  fun chatFunctions(descriptor: SerialDescriptor): List<CFunction> {
+  fun chatFunction(descriptor: SerialDescriptor): CFunction {
     val fnName = descriptor.serialName.substringAfterLast(".")
-    return chatFunctions(fnName, encodeJsonSchema(descriptor))
+    return chatFunction(fnName, encodeJsonSchema(descriptor))
   }
 
-  fun chatFunctions(fnName: String, schema: String): List<CFunction> =
-    listOf(CFunction(fnName, "Generated function for $fnName", schema))
+  fun chatFunction(fnName: String, schema: String): CFunction =
+    CFunction(fnName, "Generated function for $fnName", schema)
 
   @OptIn(ExperimentalSerializationApi::class)
   @AiDsl
@@ -53,7 +53,7 @@ interface ChatWithFunctions : Chat {
     scope: Conversation,
     serializer: KSerializer<A>,
   ): A =
-    prompt(prompt, scope, chatFunctions(serializer.descriptor)) { json ->
+    prompt(prompt, scope, chatFunction(serializer.descriptor)) { json ->
       Json.decodeFromString(serializer, json)
     }
 
@@ -61,10 +61,10 @@ interface ChatWithFunctions : Chat {
   suspend fun <A> prompt(
     prompt: Prompt,
     scope: Conversation,
-    functions: List<CFunction>,
+    function: CFunction,
     serializer: (json: String) -> A,
   ): A {
-    val promptWithFunctions = prompt.copy(functions = functions)
+    val promptWithFunctions = prompt.copy(function = function)
     return tryDeserialize(
       serializer,
       promptWithFunctions.configuration.maxDeserializationAttempts

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/functions/CFunction.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/functions/CFunction.kt
@@ -1,3 +1,6 @@
 package com.xebia.functional.xef.llm.models.functions
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class CFunction(val name: String, val description: String, val parameters: String)

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/Prompt.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/Prompt.kt
@@ -16,16 +16,16 @@ data class Prompt
 @JvmOverloads
 constructor(
   val messages: List<Message>,
-  val functions: List<CFunction> = emptyList(),
+  val function: CFunction? = null,
   val configuration: PromptConfiguration = PromptConfiguration.DEFAULTS
 ) {
 
-  constructor(value: String) : this(listOf(user(value)), emptyList())
+  constructor(value: String) : this(listOf(user(value)), null)
 
   constructor(
     value: String,
     configuration: PromptConfiguration
-  ) : this(listOf(user(value)), emptyList(), configuration)
+  ) : this(listOf(user(value)), null, configuration)
 
   companion object {
     operator fun invoke(block: PromptBuilder.() -> Unit): Prompt =

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/Prompt.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/Prompt.kt
@@ -1,6 +1,7 @@
 package com.xebia.functional.xef.prompt
 
 import com.xebia.functional.xef.llm.models.chat.Message
+import com.xebia.functional.xef.llm.models.functions.CFunction
 import com.xebia.functional.xef.prompt.configuration.PromptConfiguration
 import com.xebia.functional.xef.prompt.templates.user
 import kotlin.jvm.JvmOverloads
@@ -15,15 +16,16 @@ data class Prompt
 @JvmOverloads
 constructor(
   val messages: List<Message>,
+  val functions: List<CFunction> = emptyList(),
   val configuration: PromptConfiguration = PromptConfiguration.DEFAULTS
 ) {
 
-  constructor(value: String) : this(listOf(user(value)))
+  constructor(value: String) : this(listOf(user(value)), emptyList())
 
   constructor(
     value: String,
     configuration: PromptConfiguration
-  ) : this(listOf(user(value)), configuration)
+  ) : this(listOf(user(value)), emptyList(), configuration)
 
   companion object {
     operator fun invoke(block: PromptBuilder.() -> Unit): Prompt =

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/PromptBuilder.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/PromptBuilder.kt
@@ -2,9 +2,12 @@ package com.xebia.functional.xef.prompt
 
 import com.xebia.functional.xef.llm.models.chat.Message
 import com.xebia.functional.xef.llm.models.chat.Role
+import com.xebia.functional.xef.llm.models.functions.CFunction
+import kotlin.jvm.JvmName
 
 open class PromptBuilder {
   private val items = mutableListOf<Message>()
+  private val functions = mutableListOf<CFunction>()
 
   operator fun Prompt.unaryPlus() {
     +messages
@@ -14,13 +17,22 @@ open class PromptBuilder {
     items.add(this)
   }
 
+  operator fun CFunction.unaryPlus() {
+    functions.add(this)
+  }
+
+  @JvmName("addFunctions")
+  operator fun List<CFunction>.unaryPlus() {
+    functions.addAll(this)
+  }
+
   operator fun List<Message>.unaryPlus() {
     items.addAll(this)
   }
 
   protected open fun preprocess(elements: List<Message>): List<Message> = elements
 
-  fun build(): Prompt = Prompt(preprocess(items))
+  fun build(): Prompt = Prompt(preprocess(items), functions)
 }
 
 fun String.message(role: Role): Message = Message(role, this, role.name)

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/PromptBuilder.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/prompt/PromptBuilder.kt
@@ -2,12 +2,9 @@ package com.xebia.functional.xef.prompt
 
 import com.xebia.functional.xef.llm.models.chat.Message
 import com.xebia.functional.xef.llm.models.chat.Role
-import com.xebia.functional.xef.llm.models.functions.CFunction
-import kotlin.jvm.JvmName
 
 open class PromptBuilder {
   private val items = mutableListOf<Message>()
-  private val functions = mutableListOf<CFunction>()
 
   operator fun Prompt.unaryPlus() {
     +messages
@@ -17,22 +14,13 @@ open class PromptBuilder {
     items.add(this)
   }
 
-  operator fun CFunction.unaryPlus() {
-    functions.add(this)
-  }
-
-  @JvmName("addFunctions")
-  operator fun List<CFunction>.unaryPlus() {
-    functions.addAll(this)
-  }
-
   operator fun List<Message>.unaryPlus() {
     items.addAll(this)
   }
 
   protected open fun preprocess(elements: List<Message>): List<Message> = elements
 
-  fun build(): Prompt = Prompt(preprocess(items), functions)
+  fun build(): Prompt = Prompt(preprocess(items), null)
 }
 
 fun String.message(role: Role): Message = Message(role, this, role.name)

--- a/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk21/gpt4all/Chat.java
+++ b/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk21/gpt4all/Chat.java
@@ -45,7 +45,7 @@ public class Chat {
                 String line = br.readLine();
                 if (line.equals("exit")) break;
 
-                var answer = scope.promptStreaming(gpt4all, new Prompt(line));
+                var answer = scope.promptStreamingToPublisher(gpt4all, new Prompt(line));
 
                 answer.subscribe(new Subscriber<String>() {
                     StringBuilder answer = new StringBuilder();

--- a/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk8/Book.java
+++ b/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk8/Book.java
@@ -14,8 +14,10 @@ public class Book {
 
     public static void main(String[] args) throws ExecutionException, InterruptedException {
         try (PlatformConversation scope = OpenAI.conversation()) {
-            scope.prompt(OpenAI.FromEnvironment.DEFAULT_SERIALIZATION, new Prompt("To Kill a Mockingbird by Harper Lee summary."), Book.class)
-                  .thenAccept(book -> System.out.println("To Kill a Mockingbird summary:\n" + book.summary))
+            scope.prompt(OpenAI.FromEnvironment.DEFAULT_SERIALIZATION, new Prompt("Produce a 50 word `summary` of `To Kill a Mockingbird` by Harper Lee summary."), Book.class)
+                  .thenAccept(book ->
+                          System.out.println("To Kill a Mockingbird summary:\n" + book.summary)
+                  )
                   .get();
         }
     }

--- a/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk8/gpt4all/Chat.java
+++ b/examples/java/src/main/java/com/xebia/functional/xef/java/auto/jdk8/gpt4all/Chat.java
@@ -48,7 +48,7 @@ public class Chat {
                 String line = br.readLine();
                 if (line.equals("exit")) break;
 
-                Publisher<String> answer = scope.promptStreaming(gpt4all, new Prompt(line));
+                Publisher<String> answer = scope.promptStreamingToPublisher(gpt4all, new Prompt(line));
 
                 answer.subscribe(new Subscriber<String>() {
                     StringBuilder answer = new StringBuilder();

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/Love.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/Love.kt
@@ -1,12 +1,13 @@
 package com.xebia.functional.xef.auto
 
 import com.xebia.functional.xef.auto.llm.openai.OpenAI
+import com.xebia.functional.xef.auto.llm.openai.prompt
 import com.xebia.functional.xef.auto.llm.openai.promptMessage
 import com.xebia.functional.xef.prompt.Prompt
 
 suspend fun main() {
   OpenAI.conversation {
-    val love: String = promptMessage(Prompt("tell me you like me with just emojis"))
+    val love: String = prompt(Prompt("tell me you like me with just emojis"))
     println(love)
   }
 }

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/Love.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/Love.kt
@@ -2,7 +2,6 @@ package com.xebia.functional.xef.auto
 
 import com.xebia.functional.xef.auto.llm.openai.OpenAI
 import com.xebia.functional.xef.auto.llm.openai.prompt
-import com.xebia.functional.xef.auto.llm.openai.promptMessage
 import com.xebia.functional.xef.prompt.Prompt
 
 suspend fun main() {

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/tot/ControlSignal.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/tot/ControlSignal.kt
@@ -2,7 +2,6 @@ package com.xebia.functional.xef.auto.tot
 
 import com.xebia.functional.xef.auto.Conversation
 import com.xebia.functional.xef.auto.llm.openai.prompt
-import com.xebia.functional.xef.prompt.Prompt
 import kotlinx.serialization.Serializable
 
 @Serializable data class ControlSignal(val value: String)
@@ -28,7 +27,7 @@ internal suspend fun <A> Conversation.controlSignal(memory: Memory<A>): ControlS
     |
   """
       .trimMargin()
-  return prompt<ControlSignal>(Prompt(guidancePrompt)).also {
+  return prompt<String, ControlSignal>(guidancePrompt).also {
     println("🧠 Generated control signal: ${truncateText(it.value)}")
   }
 }

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/tot/Solution.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/auto/tot/Solution.kt
@@ -52,7 +52,7 @@ internal suspend fun <A> Conversation.solution(
        |
        |"""
       .trimMargin()
-  return prompt(OpenAI().DEFAULT_SERIALIZATION, Prompt(enhancedPrompt), serializer).also {
+  return OpenAI().DEFAULT_SERIALIZATION.prompt(Prompt(enhancedPrompt), serializer).also {
     println("🤖 Generated solution: ${truncateText(it.answer)}")
   }
 }

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/DeserializerLLMAgent.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/DeserializerLLMAgent.kt
@@ -4,9 +4,7 @@ import com.xebia.functional.xef.auto.AiDsl
 import com.xebia.functional.xef.auto.Conversation
 import com.xebia.functional.xef.llm.ChatWithFunctions
 import com.xebia.functional.xef.prompt.Prompt
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 
 /**
@@ -18,25 +16,5 @@ import kotlinx.serialization.serializer
  * @throws IllegalArgumentException if any of [A]'s type arguments contains star projection.
  */
 @AiDsl
-suspend inline fun <reified A> Conversation.prompt(
-  model: ChatWithFunctions,
-  prompt: Prompt,
-  json: Json = Json {
-    ignoreUnknownKeys = true
-    isLenient = true
-  }
-): A = prompt(model, prompt, serializer(), json)
-
-@AiDsl
-suspend fun <A> Conversation.prompt(
-  model: ChatWithFunctions,
-  prompt: Prompt,
-  serializer: KSerializer<A>,
-  json: Json = Json {
-    ignoreUnknownKeys = true
-    isLenient = true
-  }
-): A {
-  val functions = model.generateCFunction(serializer.descriptor)
-  return model.prompt(prompt, this, { json.decodeFromString(serializer, it) }, functions)
-}
+suspend inline fun <reified A> Conversation.prompt(model: ChatWithFunctions, prompt: Prompt): A =
+  model.prompt(prompt, serializer())

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIScopeExtensions.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/auto/llm/openai/OpenAIScopeExtensions.kt
@@ -4,7 +4,6 @@ import com.xebia.functional.xef.auto.AiDsl
 import com.xebia.functional.xef.auto.Conversation
 import com.xebia.functional.xef.llm.Chat
 import com.xebia.functional.xef.llm.ChatWithFunctions
-import com.xebia.functional.xef.llm.models.functions.CFunction
 import com.xebia.functional.xef.prompt.Prompt
 import kotlinx.serialization.serializer
 
@@ -13,13 +12,6 @@ suspend fun Conversation.promptMessage(
   prompt: Prompt,
   model: Chat = OpenAI().DEFAULT_CHAT
 ): String = model.promptMessage(prompt, this)
-
-@AiDsl
-suspend fun Conversation.promptMessage(
-  prompt: Prompt,
-  model: Chat = OpenAI().DEFAULT_CHAT,
-  functions: List<CFunction> = emptyList()
-): List<String> = model.promptMessages(prompt, this, functions)
 
 @AiDsl
 suspend inline fun <reified A, reified B> Conversation.prompt(
@@ -34,9 +26,3 @@ suspend inline fun <reified A, reified B> Conversation.prompt(
     outputSerializer = serializer<B>()
   )
 }
-
-@AiDsl
-suspend inline fun <reified A> Conversation.prompt(
-  prompt: Prompt,
-  model: ChatWithFunctions = OpenAI().DEFAULT_SERIALIZATION
-): A = prompt(model = model, prompt = prompt, serializer = serializer<A>())

--- a/scala/src/main/scala/com/xebia/functional/xef/scala/auto/package.scala
+++ b/scala/src/main/scala/com/xebia/functional/xef/scala/auto/package.scala
@@ -30,7 +30,7 @@ def prompt[A: Decoder: SerialDescriptor](
     def fromJson(json: String): A =
       parse(json).flatMap(Decoder[A].decodeJson(_)).fold(throw _, identity)
   }
-  conversation.prompt(chat, prompt, chat.chatFunctions(SerialDescriptor[A].serialDescriptor), fromJson).join()
+  conversation.prompt(chat, prompt, chat.chatFunction(SerialDescriptor[A].serialDescriptor), fromJson).join()
 
 def promptMessage(
     prompt: Prompt,


### PR DESCRIPTION
This PR simplifies how we thread functions and makes Prompts aware of the functions.
In the following PR, I plan on moving out of the `Chat` and `ChatWithFunctions` interfaces, the logic related to counting tokens for messages, and similar inside the Prompt area where all the information sent now that it includes functions contained in a single place.