### PR TITLE
Upgrade JDK version to 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 20
 
       - name: Build and Test (multip)
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/create-version-tag-manually.yml
+++ b/.github/workflows/create-version-tag-manually.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 20
 
       - name: Extract parameters from selected choice
         id: extract-parameters

--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 20
 
       - name: Build
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish-development-version.yml
+++ b/.github/workflows/publish-development-version.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 20
 
       - name: assemble
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 20
 
       - name: assemble
         uses: gradle/gradle-build-action@v2

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ libraryDependencies += "com.xebia" %% "xef-scala" % "<version>"
 
 > **Warning**
 > `xef-scala` is currently only available for Scala 3, and depends on project [Loom](https://openjdk.org/projects/loom/),
-> so you will need at least Java 19 to use the library.
+> so you will need at least Java 20 to use the library.
 
 </details>
 

--- a/buildSrc/src/main/kotlin/JavaPublishingConventionsPlugin.kt
+++ b/buildSrc/src/main/kotlin/JavaPublishingConventionsPlugin.kt
@@ -21,10 +21,6 @@ class JavaPublishingConventionsPlugin : Plugin<Project> {
       extensions.findByType<SigningExtension>()
         ?: throw IllegalStateException("The Signing plugin is required to digitally sign the built artifacts")
 
-    val basePluginExtension: BasePluginExtension =
-      extensions.findByType<BasePluginExtension>()
-        ?: throw IllegalStateException("The Base plugin is required to configure the name of artifacts")
-
     publishingExtension.run {
       publications {
         register<MavenPublication>("maven") {

--- a/buildSrc/src/main/kotlin/ScalaPublishingConventionsPlugin.kt
+++ b/buildSrc/src/main/kotlin/ScalaPublishingConventionsPlugin.kt
@@ -18,7 +18,7 @@ class ScalaPublishingConventionsPlugin : Plugin<Project> {
       tasks.findByName("scaladoc")?.let { dependsOn(it) }
         ?: errorMessage("The scaladoc task was not found. The Javadoc jar file won't contain any documentation")
       archiveClassifier.set("javadoc")
-      from("$buildDir/docs/scaladoc")
+      from("${layout.buildDirectory.get()}/docs/scaladoc")
     }
 
     val publishingExtension: PublishingExtension =

--- a/docs/intro/scala.md
+++ b/docs/intro/scala.md
@@ -76,7 +76,7 @@ Set the environment variable `OPENAI_TOKEN=xxx`
 ### Project Loom
 
 The Scala module depends on project [Loom](https://openjdk.org/projects/loom/), 
-so you will need at least Java 19 to use the library. Furthermore, you need to pass
+so you will need at least Java 20 to use the library. Furthermore, you need to pass
 the `--enable-preview` flag.
 
 <details>
@@ -90,7 +90,7 @@ env OPENAI_TOKEN=<your-token> sbt -J--enable-preview <your-command>
 <details>
 <summary>IntelliJ</summary>
 
-- Set the Java version to at least 19
+- Set the Java version to at least 20
 - Set VM options to `--enable-preview`
 
 </details>

--- a/examples/scala/build.gradle.kts
+++ b/examples/scala/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 }
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_19
-  targetCompatibility = JavaVersion.VERSION_19
+  sourceCompatibility = JavaVersion.VERSION_20
+  targetCompatibility = JavaVersion.VERSION_20
   toolchain {
-    languageVersion = JavaLanguageVersion.of(19)
+    languageVersion = JavaLanguageVersion.of(20)
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scala/build.gradle.kts
+++ b/scala/build.gradle.kts
@@ -25,10 +25,10 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_19
-    targetCompatibility = JavaVersion.VERSION_19
+    sourceCompatibility = JavaVersion.VERSION_20
+    targetCompatibility = JavaVersion.VERSION_20
     toolchain {
-        languageVersion = JavaLanguageVersion.of(19)
+        languageVersion = JavaLanguageVersion.of(20)
     }
     withSourcesJar()
 }


### PR DESCRIPTION
The `Scala` modules require using the latest versions of Java because they depend on the `loom`  project for structured concurrency. So far, we have been using version 19, but a new STS version (Java 20) was recently released to replace the former one.