### PR TITLE
OpenAIToken env var is not necessary in the endpoint

### DIFF
--- a/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/Routes.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/http/routes/Routes.kt
@@ -53,19 +53,9 @@ fun Routing.routes(
 
     authenticate("auth-bearer") {
         post("/chat/completions") {
-            val provider: Provider = call.getProvider()
             val token = call.getToken()
-            val scope = Conversation(persistenceService.getVectorStore(provider, token))
             val context = call.receive<String>()
             val data = Json.decodeFromString<JsonObject>(context)
-            if (!data.containsKey("model")) {
-                call.respondText("No model found", status = HttpStatusCode.BadRequest)
-                return@post
-            }
-            val model: OpenAIModel = data["model"]?.jsonPrimitive?.content?.toOpenAIModel(token) ?: run {
-                call.respondText("No model found", status = HttpStatusCode.BadRequest)
-                return@post
-            }
 
             val isStream = data["stream"]?.jsonPrimitive?.boolean ?: false
 


### PR DESCRIPTION
In `xef-server` we are loading conversation scope and they are not necessary for the endpoint. For that, we need the `OPENAI_TOKEN` env var assigned although it is unnecessary as we are passing it in the header.

This PR removes this unnecessary code