### PR TITLE
Refactor API service in its own function

### DIFF
--- a/server/web/src/components/Pages/GenericQuestion/GenericQuestion.tsx
+++ b/server/web/src/components/Pages/GenericQuestion/GenericQuestion.tsx
@@ -15,49 +15,9 @@ import { HourglassLoader } from '@/components/HourglassLoader';
 import { LoadingContext } from '@/state/Loading';
 import { SettingsContext } from '@/state/Settings';
 
-import {
-  ApiOptions,
-  EndpointsEnum,
-  apiConfigConstructor,
-  apiFetch,
-  defaultApiServer,
-} from '@/utils/api';
+import { postChatCompletions } from '@/utils/api';
 
 import styles from './GenericQuestion.module.css';
-
-const baseHeaders = {
-  Accept: 'application/json',
-  'Content-Type': 'application/json',
-};
-
-const chatCompletionsBaseRequest: ChatCompletionsRequest = {
-  model: 'gpt-3.5-turbo-16k',
-  messages: [
-    {
-      role: 'user',
-      content: '',
-      name: 'USER',
-    },
-  ],
-  temperature: 0.4,
-  top_p: 1.0,
-  n: 1,
-  max_tokens: 12847,
-  presence_penalty: 0.0,
-  frequency_penalty: 0.0,
-  logit_bias: {},
-  user: 'USER',
-};
-
-const chatCompletionsApiBaseOptions: ApiOptions = {
-  endpointServer: defaultApiServer,
-  endpointPath: EndpointsEnum.chatCompletions,
-  endpointValue: '',
-  requestOptions: {
-    method: 'POST',
-    headers: baseHeaders,
-  },
-};
 
 export function GenericQuestion() {
   const [loading, setLoading] = useContext(LoadingContext);
@@ -73,34 +33,13 @@ export function GenericQuestion() {
         setLoading(true);
         console.group(`🖱️ Generic question form used:`);
 
-        const chatCompletionsRequest: ChatCompletionsRequest = {
-          ...chatCompletionsBaseRequest,
-          messages: [
-            {
-              ...chatCompletionsBaseRequest.messages[0],
-              content: prompt,
-            },
-          ],
-        };
-        const chatCompletionsApiOptions: ApiOptions = {
-          ...chatCompletionsApiBaseOptions,
-          body: JSON.stringify(chatCompletionsRequest),
-          requestOptions: {
-            ...chatCompletionsApiBaseOptions.requestOptions,
-            headers: {
-              ...chatCompletionsApiBaseOptions.requestOptions?.headers,
-              Authorization: `Bearer ${settings.apiKey}`,
-            },
-          },
-        };
-        const chatCompletionsApiConfig = apiConfigConstructor(
-          chatCompletionsApiOptions,
-        );
-        const chatCompletionResponse = await apiFetch<ChatCompletionsResponse>(
-          chatCompletionsApiConfig,
-        );
-        const { content } = chatCompletionResponse.choices[0].message;
+        if (!settings.apiKey) throw 'API key not set';
 
+        const chatCompletionResponse = await postChatCompletions({
+          apiKey: settings.apiKey,
+          prompt,
+        });
+        const { content } = chatCompletionResponse.choices[0].message;
         setResponseMessage(content);
 
         console.info(`Chat completions request completed`);
@@ -108,7 +47,7 @@ export function GenericQuestion() {
         const userFriendlyError = `Chat completions request couldn't be completed`;
         console.info(userFriendlyError);
         setShowAlert(`
-              ${userFriendlyError}, is the API key set?`);
+              ${userFriendlyError}. ${error}`);
       } finally {
         console.groupEnd();
         setLoading(false);
@@ -190,7 +129,7 @@ export function GenericQuestion() {
       <Snackbar
         open={!!showAlert}
         onClose={(_, reason) => reason !== 'clickaway' && setShowAlert('')}
-        autoHideDuration={3000}>
+        autoHideDuration={5000}>
         <Alert severity="error">{showAlert}</Alert>
       </Snackbar>
     </>

--- a/server/web/src/utils/api/chatCompletions.ts
+++ b/server/web/src/utils/api/chatCompletions.ts
@@ -1,0 +1,80 @@
+import {
+  ApiKeyProp,
+  ApiOptions,
+  EndpointsEnum,
+  apiConfigConstructor,
+  apiFetch,
+  defaultApiServer,
+} from '@/utils/api';
+
+const baseHeaders = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+};
+
+const chatCompletionsBaseRequest: ChatCompletionsRequest = {
+  model: 'gpt-3.5-turbo-16k',
+  messages: [
+    {
+      role: 'user',
+      content: '',
+      name: 'USER',
+    },
+  ],
+  temperature: 0.4,
+  top_p: 1.0,
+  n: 1,
+  max_tokens: 12847,
+  presence_penalty: 0.0,
+  frequency_penalty: 0.0,
+  logit_bias: {},
+  user: 'USER',
+};
+
+const chatCompletionsApiBaseOptions: ApiOptions = {
+  endpointServer: defaultApiServer,
+  endpointPath: EndpointsEnum.chatCompletions,
+  endpointValue: '',
+  requestOptions: {
+    method: 'POST',
+    headers: baseHeaders,
+  },
+};
+
+export type PostChatCompletionsProps = ApiKeyProp & {
+  prompt: string;
+};
+
+export async function postChatCompletions({
+  prompt,
+  apiKey,
+}: PostChatCompletionsProps): Promise<ChatCompletionsResponse> {
+  const chatCompletionsRequest: ChatCompletionsRequest = {
+    ...chatCompletionsBaseRequest,
+    messages: [
+      {
+        ...chatCompletionsBaseRequest.messages[0],
+        content: prompt,
+      },
+    ],
+  };
+  const chatCompletionsApiOptions: ApiOptions = {
+    ...chatCompletionsApiBaseOptions,
+    body: JSON.stringify(chatCompletionsRequest),
+    requestOptions: {
+      ...chatCompletionsApiBaseOptions.requestOptions,
+      headers: {
+        ...chatCompletionsApiBaseOptions.requestOptions?.headers,
+        Authorization: `Bearer ${apiKey}`,
+      },
+    },
+  };
+  const chatCompletionsApiConfig = apiConfigConstructor(
+    chatCompletionsApiOptions,
+  );
+  const chatCompletionResponse = await apiFetch<ChatCompletionsResponse>(
+    chatCompletionsApiConfig,
+  );
+
+  return chatCompletionResponse;
+}

--- a/server/web/src/utils/api/config.ts
+++ b/server/web/src/utils/api/config.ts
@@ -105,7 +105,6 @@ export async function apiFetch<T = Record<string, unknown>>(
 
     return responseData;
   } catch (error) {
-    console.log(error);
     const errorMessage = `💢 Error: ${error}`;
     console.error(errorMessage);
     throw errorMessage;

--- a/server/web/src/utils/api/index.ts
+++ b/server/web/src/utils/api/index.ts
@@ -1,0 +1,2 @@
+export * from './config';
+export * from './chatCompletions';


### PR DESCRIPTION
## Description

This PR just refactor the `chatCompletions` API functions into its own function, for a better code organization, reusage, and readability

It also tries to show actual errors that may come from the `xef-server` API, even if they incorrectly respond with `200` codes.