### PR TITLE
server: fix mysterious ktor client engine timeout

### DIFF
--- a/server/src/main/kotlin/com/xebia/functional/xef/server/Server.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/Server.kt
@@ -37,6 +37,9 @@ object Server {
             persistenceService.addCollection()
 
             val ktorClient = HttpClient(CIO){
+                engine {
+                    requestTimeout = 0 // disabled
+                }
                 install(Auth)
                 install(Logging) {
                     level = LogLevel.INFO


### PR DESCRIPTION
Streaming long prompts resulted in timeout, exceptions or deadlock.
Observed behavior was not consistent.
Root cause was that by default the CIO engine has a timeout of 15s. Setting this 0, disables the timeout.