### PR TITLE
Vite env file

### DIFF
--- a/server/web/src/utils/vite-env.d.ts
+++ b/server/web/src/utils/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
TypeScript does not know that there are files other than .ts or .tsx so it will throw an error if an import has an unknown file suffix. This env file ([more information here about env files in Vite](https://v2.vitejs.dev/guide/env-and-mode.html#env-files)) contains a vite reference in order to add commons files to the project and VSCode IDE doesn't complain about such files