### PR TITLE
storing full prompt and response messages

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
@@ -36,11 +36,7 @@ interface Chat : LLM {
       .also { finalText ->
         val aiResponseMessage = assistant(finalText)
         val newMessages = prompt.messages + listOf(aiResponseMessage)
-        MemoryManagement.addMemoriesAfterStream(
-          this@Chat,
-          newMessages,
-          scope
-        )
+        MemoryManagement.addMessagesToMemory(this@Chat, newMessages, scope)
       }
   }
 
@@ -64,7 +60,7 @@ interface Chat : LLM {
     return MemoryManagement.run {
       createChatCompletion(request)
         .choices
-        .addChoiceToMemory(this@Chat, request, scope)
+        .addChoiceToMemory(this@Chat, prompt.messages, scope)
         .mapNotNull { it.message?.content }
     }
   }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
@@ -34,12 +34,12 @@ interface Chat : LLM {
       .onEach { emit(it) }
       .fold("", String::plus)
       .also { finalText ->
-        val message = assistant(finalText)
+        val aiResponseMessage = assistant(finalText)
+        val newMessages = prompt.messages + listOf(aiResponseMessage)
         MemoryManagement.addMemoriesAfterStream(
           this@Chat,
-          request.messages.lastOrNull(),
-          scope,
-          listOf(message)
+          newMessages,
+          scope
         )
       }
   }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
@@ -91,11 +91,7 @@ interface ChatWithFunctions : LLM {
       MemoryManagement.run {
         createChatCompletionWithFunctions(request)
           .choices
-          .addChoiceWithFunctionsToMemory(
-            this@ChatWithFunctions,
-            request.messages.lastOrNull(),
-            scope
-          )
+          .addChoiceWithFunctionsToMemory(this@ChatWithFunctions, prompt.messages, scope)
           .mapNotNull { it.message?.functionCall?.arguments }
       }
     }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
@@ -88,12 +88,11 @@ interface ChatWithFunctions : LLM {
       serializer,
       promptWithFunctions.configuration.maxDeserializationAttempts
     ) {
-      MemoryManagement.run {
-        createChatCompletionWithFunctions(request)
-          .choices
-          .addChoiceWithFunctionsToMemory(this@ChatWithFunctions, prompt.messages, scope)
-          .mapNotNull { it.message?.functionCall?.arguments }
-      }
+      val requestedMemories = prompt.messages.toMemory(this@ChatWithFunctions, scope)
+      createChatCompletionWithFunctions(request)
+        .choices
+        .addMessagesToMemory(this@ChatWithFunctions, scope, requestedMemories)
+        .mapNotNull { it.message?.functionCall?.arguments }
     }
   }
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
@@ -134,6 +134,7 @@ interface ChatWithFunctions : LLM {
       ) {
         streamFunctionCall(
           chat = this@ChatWithFunctions,
+          promptMessages = prompt.messages,
           request = request,
           scope = scope,
           serializer = serializer,

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MemoryManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MemoryManagement.kt
@@ -5,66 +5,67 @@ import com.xebia.functional.xef.llm.models.chat.*
 import com.xebia.functional.xef.store.Memory
 import io.ktor.util.date.*
 
-internal object MemoryManagement {
-
-  internal suspend fun addMessagesToMemory(
-    chat: LLM,
-    messages: List<Message>,
-    scope: Conversation
-  ) {
-    val cid = scope.conversationId
-    if (cid != null) {
-      val memories =
-        messages.map {
-          Memory(
-            conversationId = cid,
-            content = it,
-            timestamp = getTimeMillis(),
-            approxTokens = chat.tokensFromMessages(listOf(it))
-          )
-        }
-      scope.store.addMemories(memories)
-    }
+internal suspend fun List<Message>.addToMemory(chat: LLM, scope: Conversation) {
+  val memories = toMemory(chat, scope)
+  if (memories.isNotEmpty()) {
+    scope.store.addMemories(memories)
   }
+}
 
-  internal suspend fun List<ChoiceWithFunctions>.addChoiceWithFunctionsToMemory(
-    chat: LLM,
-    requestUserMessages: List<Message>,
-    scope: Conversation
-  ): List<ChoiceWithFunctions> = also {
-    val firstChoice = firstOrNull()
-    val cid = scope.conversationId
-    if (firstChoice != null && cid != null) {
-      val role = firstChoice.message?.role?.uppercase()?.let { Role.valueOf(it) } ?: Role.USER
-
-      val firstChoiceMessage =
-        Message(
-          role = role,
-          content = firstChoice.message?.content
-              ?: firstChoice.message?.functionCall?.arguments ?: "",
-          name = role.name
-        )
-
-      val newMessages = requestUserMessages + firstChoiceMessage
-      addMessagesToMemory(chat, newMessages, scope)
+internal fun List<Message>.toMemory(chat: LLM, scope: Conversation): List<Memory> {
+  val cid = scope.conversationId
+  return if (cid != null) {
+    mapIndexed { delta, it ->
+      Memory(
+        conversationId = cid,
+        content = it,
+        // We are adding the delta to ensure that the timestamp is unique for every message.
+        // With this, we ensure that the order of the messages is preserved.
+        // We assume that the AI response time will be in the order of seconds.
+        timestamp = getTimeMillis() + delta,
+        approxTokens = chat.tokensFromMessages(listOf(it))
+      )
     }
+  } else emptyList()
+}
+
+internal suspend fun List<ChoiceWithFunctions>.addMessagesToMemory(
+  chat: LLM,
+  scope: Conversation,
+  previousMemories: List<Memory>
+): List<ChoiceWithFunctions> = also {
+  val firstChoice = firstOrNull()
+  val cid = scope.conversationId
+  if (firstChoice != null && cid != null) {
+    val role = firstChoice.message?.role?.uppercase()?.let { Role.valueOf(it) } ?: Role.USER
+
+    val firstChoiceMessage =
+      Message(
+        role = role,
+        content = firstChoice.message?.content
+            ?: firstChoice.message?.functionCall?.arguments ?: "",
+        name = role.name
+      )
+
+    val newMessages = previousMemories + listOf(firstChoiceMessage).toMemory(chat, scope)
+    scope.store.addMemories(newMessages)
   }
+}
 
-  internal suspend fun List<Choice>.addChoiceToMemory(
-    chat: Chat,
-    messages: List<Message>,
-    scope: Conversation
-  ): List<Choice> = also {
-    val firstChoice = firstOrNull()
-    val cid = scope.conversationId
-    if (firstChoice != null && cid != null) {
-      val role = firstChoice.message?.role?.name?.uppercase()?.let { Role.valueOf(it) } ?: Role.USER
+internal suspend fun List<Choice>.addMessagesToMemory(
+  chat: Chat,
+  scope: Conversation,
+  previousMemories: List<Memory>
+): List<Choice> = also {
+  val firstChoice = firstOrNull()
+  val cid = scope.conversationId
+  if (firstChoice != null && cid != null) {
+    val role = firstChoice.message?.role?.name?.uppercase()?.let { Role.valueOf(it) } ?: Role.USER
 
-      val firstChoiceMessage =
-        Message(role = role, content = firstChoice.message?.content ?: "", name = role.name)
+    val firstChoiceMessage =
+      Message(role = role, content = firstChoice.message?.content ?: "", name = role.name)
 
-      val newMessages = messages + firstChoiceMessage
-      addMessagesToMemory(chat, newMessages, scope)
-    }
+    val newMessages = previousMemories + listOf(firstChoiceMessage).toMemory(chat, scope)
+    scope.store.addMemories(newMessages)
   }
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MemoryManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MemoryManagement.kt
@@ -9,20 +9,12 @@ internal object MemoryManagement {
 
   internal suspend fun addMemoriesAfterStream(
     chat: LLM,
-    lastRequestMessage: Message?,
-    scope: Conversation,
     messages: List<Message>,
+    scope: Conversation
   ) {
     val cid = scope.conversationId
-    if (cid != null && lastRequestMessage != null) {
-      val requestMemory =
-        Memory(
-          conversationId = cid,
-          content = lastRequestMessage,
-          timestamp = getTimeMillis(),
-          approxTokens = chat.tokensFromMessages(listOf(lastRequestMessage))
-        )
-      val responseMemories =
+    if (cid != null) {
+      val memories =
         messages.map {
           Memory(
             conversationId = cid,
@@ -31,7 +23,7 @@ internal object MemoryManagement {
             approxTokens = chat.tokensFromMessages(messages)
           )
         }
-      scope.store.addMemories(listOf(requestMemory) + responseMemories)
+      scope.store.addMemories(memories)
     }
   }
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
@@ -65,7 +65,7 @@ sealed class StreamedFunction<out A> {
         .createChatCompletionsWithFunctions(request)
         .onCompletion {
           val newMessages = promptMessages + messages
-          MemoryManagement.addMessagesToMemory(chat, newMessages, scope)
+          newMessages.addToMemory(chat, scope)
         }
         .collect { responseChunk ->
           // Each chunk is emitted from the LLM and it will include a delta.parameters with

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
@@ -31,7 +31,8 @@ sealed class StreamedFunction<out A> {
      * user before the final result for the function call is ready.
      *
      * @param chat the ChatWithFunctions object representing the chat.
-     * @param promptMessages prompt messages that are added to conversation history if request successful.
+     * @param promptMessages prompt messages that are added to conversation history if request
+     *   successful.
      * @param request the ChatCompletionRequest object representing the completion request.
      * @param scope the Conversation object representing the conversation scope.
      * @param serializer the function used to deserialize JSON strings into objects of type A.
@@ -64,11 +65,7 @@ sealed class StreamedFunction<out A> {
         .createChatCompletionsWithFunctions(request)
         .onCompletion {
           val newMessages = promptMessages + messages
-          MemoryManagement.addMemoriesAfterStream(
-            chat,
-            newMessages,
-            scope
-          )
+          MemoryManagement.addMessagesToMemory(chat, newMessages, scope)
         }
         .collect { responseChunk ->
           // Each chunk is emitted from the LLM and it will include a delta.parameters with

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
@@ -31,6 +31,7 @@ sealed class StreamedFunction<out A> {
      * user before the final result for the function call is ready.
      *
      * @param chat the ChatWithFunctions object representing the chat.
+     * @param promptMessages prompt messages that are added to conversation history if request successful.
      * @param request the ChatCompletionRequest object representing the completion request.
      * @param scope the Conversation object representing the conversation scope.
      * @param serializer the function used to deserialize JSON strings into objects of type A.
@@ -39,6 +40,7 @@ sealed class StreamedFunction<out A> {
     @JvmSynthetic
     internal suspend fun <A> FlowCollector<StreamedFunction<A>>.streamFunctionCall(
       chat: ChatWithFunctions,
+      promptMessages: List<Message>,
       request: FunChatCompletionRequest,
       scope: Conversation,
       serializer: (json: String) -> A,
@@ -61,11 +63,11 @@ sealed class StreamedFunction<out A> {
       chat
         .createChatCompletionsWithFunctions(request)
         .onCompletion {
+          val newMessages = promptMessages + messages
           MemoryManagement.addMemoriesAfterStream(
             chat,
-            request.messages.lastOrNull(),
-            scope,
-            messages
+            newMessages,
+            scope
           )
         }
         .collect { responseChunk ->

--- a/core/src/commonTest/kotlin/com/xebia/functional/xef/data/TestModel.kt
+++ b/core/src/commonTest/kotlin/com/xebia/functional/xef/data/TestModel.kt
@@ -7,6 +7,7 @@ import com.xebia.functional.xef.llm.models.chat.*
 import com.xebia.functional.xef.llm.models.embeddings.EmbeddingRequest
 import com.xebia.functional.xef.llm.models.embeddings.EmbeddingResult
 import com.xebia.functional.xef.llm.models.usage.Usage
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 
 class TestModel(
@@ -21,6 +22,7 @@ class TestModel(
     request: ChatCompletionRequest
   ): ChatCompletionResponse {
     requests.add(request)
+    delay(100) // Simulating a AI's delay response
     return ChatCompletionResponse(
       id = "fake-id",
       `object` = "fake-object",
@@ -31,9 +33,9 @@ class TestModel(
           Choice(
             message =
               Message(
-                role = Role.USER,
+                role = Role.ASSISTANT,
                 content = responses[request.messages.last().content] ?: "fake-content",
-                name = Role.USER.name
+                name = Role.ASSISTANT.name
               ),
             finishReason = "fake-finish-reason",
             index = 0


### PR DESCRIPTION
This PR modifies the behaviour of storing messages in memory. We realized that we were skipping possible messages from the request. The behaviour before will be something like this:

RequestMessages = ["You are an expert on classical music", "Which is the best composition of Gustav Mahler?"]
AIResponseMessage = ["One of the best compositions is Mahler's Second Symphony"]

As a result of the previous behaviour, we will end with this in the memory:
["Which is the best composition of Gustav Mahler?", "One of the best compositions is Mahler's Second Symphony"]

We are missing all the request messages except the last one. This PR fixed that adding to the memories all the request messages.