### PR TITLE
Ignoring test

### DIFF
--- a/core/src/commonTest/kotlin/com/xebia/functional/xef/conversation/ConversationSpec.kt
+++ b/core/src/commonTest/kotlin/com/xebia/functional/xef/conversation/ConversationSpec.kt
@@ -176,7 +176,11 @@ class ConversationSpec :
       response shouldBe answer
     }
 
-    "the scope's store should contains all the messages" {
+    // This test is ignored because we have some problems regarding the storing of
+    // the memory, that will need to be fixed before we can enable this test
+    // This is the ticket for the issue:
+    // https://github.com/xebia-functional/xef/issues/447
+    "!the scope's store should contains all the messages" {
       val conversationId = ConversationId(UUID.generateUUID().toString())
 
       val model = TestModel(modelType = ModelType.ADA, name = "fake-model")


### PR DESCRIPTION
This PR ignores a test due to problems in how we store the messages in the memory. This change will be done in another ticket.