### PR TITLE
Update Embeddings.kt

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Embeddings.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Embeddings.kt
@@ -18,7 +18,7 @@ interface Embeddings : LLM {
     else
       texts
         .chunked(chunkSize ?: 400)
-        .parMap { createEmbeddings(EmbeddingRequest(name, texts, requestConfig.user.id)).data }
+        .parMap { createEmbeddings(EmbeddingRequest(name, it, requestConfig.user.id)).data }
         .flatten()
 
   suspend fun embedQuery(text: String, requestConfig: RequestConfig): List<Embedding> =


### PR DESCRIPTION
When I was trying to use `addContext` in a demo I faced an error that I could reproduce by running this [example](https://github.com/xebia-functional/xef/blob/main/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/conversation/contexts/PDFDocument.kt).

I realized we were ignoring the chunks when embedding but passing all the documents multiple times.

This PR fixes this.

How to reproduce?:
- Run this [example](https://github.com/xebia-functional/xef/blob/main/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/conversation/contexts/PDFDocument.kt) before the change (it won't work)
- Run this [example](https://github.com/xebia-functional/xef/blob/main/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/conversation/contexts/PDFDocument.kt) after the change (it will work)