### PR TITLE
Fix - GenericIOException: Failed to parse HTTP response: unexpected EOF

### DIFF
--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/conversation/llm/openai/Conversions.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/conversation/llm/openai/Conversions.kt
@@ -5,6 +5,7 @@ import com.aallam.openai.api.chat.ChatCompletionChunk as OAIChatCompletionChunk
 import com.aallam.openai.api.chat.ChatDelta as OAIChatDelta
 import com.aallam.openai.api.chat.ChatRole
 import com.aallam.openai.api.core.Usage as OAIUsage
+import com.aallam.openai.api.http.Timeout as OAITimeout
 import com.xebia.functional.xef.llm.models.chat.ChatChunk
 import com.xebia.functional.xef.llm.models.chat.ChatCompletionChunk
 import com.xebia.functional.xef.llm.models.chat.ChatDelta
@@ -61,3 +62,6 @@ internal fun OAIChatDelta.toInternal() =
         else FunctionCall(it.name, it.arguments)
       }
   )
+
+internal fun OpenAI.Timeout.toOAITimeout() =
+  OAITimeout(this.request, this.connect, this.socket)

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/conversation/llm/openai/OpenAI.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/conversation/llm/openai/OpenAI.kt
@@ -35,7 +35,7 @@ class OpenAI(
   internal var timeout: Timeout = Timeout.default()
 ) : AutoCloseable, AutoClose by autoClose() {
 
-  class Timeout private constructor(
+  class Timeout(
     val request: Duration,
     val connect: Duration,
     val socket: Duration,

--- a/openai/src/commonMain/kotlin/com/xebia/functional/xef/conversation/llm/openai/OpenAI.kt
+++ b/openai/src/commonMain/kotlin/com/xebia/functional/xef/conversation/llm/openai/OpenAI.kt
@@ -41,7 +41,7 @@ class OpenAI(
     val socket: Duration,
   ) {
     companion object {
-      private val REQUEST_TIMEOUT = 30.seconds
+      private val REQUEST_TIMEOUT = 60.seconds
       private val CONNECT_TIMEOUT = 10.minutes
       private val SOCKET_TIMEOUT = 10.minutes
 


### PR DESCRIPTION
### What?
Testing our library in a simple use case we have detected that with a newly generated personal OPENAI_TOKEN. When we use it we get this exception 
`(com.aallam.openai.api.exception.GenericIOException: Failed to parse HTTP response: unexpected EOF)`

![2023-10-10_14-21](https://github.com/xebia-functional/xef/assets/1055503/5eb5eaff-e483-47e1-8d7c-5fabc0b07a18)

### Why?
Because the Timeout establishes a default time of 30 seconds for the socket, so if this request spend more time that this value (socket = 30.seconds) the execution thrown an exception.

![2023-10-11_17-13](https://github.com/xebia-functional/xef/assets/1055503/c3f13043-f561-4da9-b957-5f353be8db27)

### How?
We have added a configurable Timeout with some default values in our OpenAI class. This solves the timeout problem given by the "com.aallam" OpenAI library client, issue already closed https://github.com/aallam/openai-kotlin/issues/234

### Other minor changes:
We take the opportunity to do this little refactor:
- set the findModel function to private
- put below the private function findModel (We think that is more readable in this way)