### PR TITLE
Adapts the open-telemetry example for using agents

### DIFF
--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/conversation/conversations/Animal.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/conversation/conversations/Animal.kt
@@ -18,7 +18,9 @@ suspend fun main() {
   // To run the example with OpenTelemetry, you can execute the following commands:
   //  - # docker compose-up server/docker/opentelemetry
 
-  // OpenAI.conversation(LocalVectorStore(OpenAI().DEFAULT_EMBEDDING), OpenTelemetryMetric())
+//   OpenAI.conversation(
+//     com.xebia.functional.xef.store.LocalVectorStore(OpenAI().DEFAULT_EMBEDDING),
+//     com.xebia.functional.xef.opentelemetry.OpenTelemetryMetric()) {
 
   OpenAI.conversation {
     val animal: Animal = prompt("A unique animal species.")

--- a/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/conversation/conversations/Animal.kt
+++ b/examples/kotlin/src/main/kotlin/com/xebia/functional/xef/conversation/conversations/Animal.kt
@@ -18,9 +18,9 @@ suspend fun main() {
   // To run the example with OpenTelemetry, you can execute the following commands:
   //  - # docker compose-up server/docker/opentelemetry
 
-//   OpenAI.conversation(
-//     com.xebia.functional.xef.store.LocalVectorStore(OpenAI().DEFAULT_EMBEDDING),
-//     com.xebia.functional.xef.opentelemetry.OpenTelemetryMetric()) {
+  //   OpenAI.conversation(
+  //     com.xebia.functional.xef.store.LocalVectorStore(OpenAI().DEFAULT_EMBEDDING),
+  //     com.xebia.functional.xef.opentelemetry.OpenTelemetryMetric()) {
 
   OpenAI.conversation {
     val animal: Animal = prompt("A unique animal species.")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ suspendApp = "0.4.0"
 flyway = "9.22.3"
 resources-kmp = "0.4.0"
 detekt = "1.23.1"
-opentelemetry="1.30.1"
+opentelemetry="1.31.0"
 opentelemetry-alpha="1.30.1-alpha"
 
 [libraries]

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryConfig.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryConfig.kt
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import java.util.concurrent.TimeUnit
 
-
 data class OpenTelemetryConfig(
   val endpointConfig: String,
   val defaultScopeName: String,
@@ -32,7 +31,8 @@ data class OpenTelemetryConfig(
         .build()
 
     val resource =
-      Resource.getDefault().toBuilder()
+      Resource.getDefault()
+        .toBuilder()
         .put(AttributeKey.stringKey("service.name"), serviceName)
         .build()
 
@@ -42,24 +42,29 @@ data class OpenTelemetryConfig(
         .setResource(resource)
         .build()
 
-    val meterProvider = SdkMeterProvider.builder()
-      .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder().build()).build())
-      .setResource(resource)
-      .build()
+    val meterProvider =
+      SdkMeterProvider.builder()
+        .registerMetricReader(
+          PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder().build()).build()
+        )
+        .setResource(resource)
+        .build()
 
-    val loggerProvider = SdkLoggerProvider.builder()
-      .addLogRecordProcessor(
-        BatchLogRecordProcessor.builder(OtlpGrpcLogRecordExporter.builder().build()).build()
-      )
-      .setResource(resource)
-      .build()
+    val loggerProvider =
+      SdkLoggerProvider.builder()
+        .addLogRecordProcessor(
+          BatchLogRecordProcessor.builder(OtlpGrpcLogRecordExporter.builder().build()).build()
+        )
+        .setResource(resource)
+        .build()
 
-    val openTelemetry = OpenTelemetrySdk.builder()
-      .setTracerProvider(tracerProvider)
-      .setMeterProvider(meterProvider)
-      .setLoggerProvider(loggerProvider)
-      .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-      .buildAndRegisterGlobal()
+    val openTelemetry =
+      OpenTelemetrySdk.builder()
+        .setTracerProvider(tracerProvider)
+        .setMeterProvider(meterProvider)
+        .setLoggerProvider(loggerProvider)
+        .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+        .buildAndRegisterGlobal()
 
     Runtime.getRuntime().addShutdownHook(Thread { openTelemetry.close() })
     return openTelemetry

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryConfig.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryConfig.kt
@@ -2,13 +2,21 @@ package com.xebia.functional.xef.opentelemetry
 
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.logs.SdkLoggerProvider
+import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import java.util.concurrent.TimeUnit
+
 
 data class OpenTelemetryConfig(
   val endpointConfig: String,
@@ -17,24 +25,43 @@ data class OpenTelemetryConfig(
 ) {
 
   fun newInstance(): OpenTelemetry {
-    val jaegerOtlpExporter: OtlpGrpcSpanExporter =
+    val otlpGrpcSpanExporter: OtlpGrpcSpanExporter =
       OtlpGrpcSpanExporter.builder()
         .setEndpoint(endpointConfig)
         .setTimeout(30, TimeUnit.SECONDS)
         .build()
 
-    val serviceNameResource: Resource =
-      Resource.create(Attributes.of(AttributeKey.stringKey("service.name"), serviceName))
+    val resource =
+      Resource.getDefault().toBuilder()
+        .put(AttributeKey.stringKey("service.name"), serviceName)
+        .build()
 
     val tracerProvider =
       SdkTracerProvider.builder()
-        .addSpanProcessor(BatchSpanProcessor.builder(jaegerOtlpExporter).build())
-        .setResource(Resource.getDefault().merge(serviceNameResource))
+        .addSpanProcessor(BatchSpanProcessor.builder(otlpGrpcSpanExporter).build())
+        .setResource(resource)
         .build()
 
-    val openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()
+    val meterProvider = SdkMeterProvider.builder()
+      .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder().build()).build())
+      .setResource(resource)
+      .build()
 
-    Runtime.getRuntime().addShutdownHook(Thread { tracerProvider.close() })
+    val loggerProvider = SdkLoggerProvider.builder()
+      .addLogRecordProcessor(
+        BatchLogRecordProcessor.builder(OtlpGrpcLogRecordExporter.builder().build()).build()
+      )
+      .setResource(resource)
+      .build()
+
+    val openTelemetry = OpenTelemetrySdk.builder()
+      .setTracerProvider(tracerProvider)
+      .setMeterProvider(meterProvider)
+      .setLoggerProvider(loggerProvider)
+      .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+      .buildAndRegisterGlobal()
+
+    Runtime.getRuntime().addShutdownHook(Thread { openTelemetry.close() })
     return openTelemetry
   }
 

--- a/server/docker/opentelemetry/docker-compose.yml
+++ b/server/docker/opentelemetry/docker-compose.yml
@@ -1,9 +1,44 @@
-version: "3"
+version: "4"
 services:
-  jaeger:
+
+  # Jaeger
+  jaeger-all-in-one:
     image: jaegertracing/all-in-one:latest
-    environment:
-      COLLECTOR_OTLP_ENABLED: true
+    restart: always
     ports:
-      - 4317:4317
-      - 16686:16686
+      - "16686:16686"
+      - "14268"
+      - "14250"
+
+  # Zipkin
+  zipkin-all-in-one:
+    image: openzipkin/zipkin:latest
+    restart: always
+    ports:
+      - "9411:9411"
+
+  # Collector
+  otel-collector:
+    image: otel/opentelemetry-collector:0.85.0
+    restart: always
+    command: ["--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "1888:1888"   # pprof extension
+      - "8888:8888"   # Prometheus metrics exposed by the collector
+      - "8889:8889"   # Prometheus exporter metrics
+      - "13133:13133" # health_check extension
+      - "4317:4317"   # OTLP gRPC receiver
+      - "55679:55679" # zpages extension
+    depends_on:
+      - jaeger-all-in-one
+      - zipkin-all-in-one
+
+  prometheus:
+    image: prom/prometheus:latest
+    restart: always
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"

--- a/server/docker/opentelemetry/otel-collector-config.yaml
+++ b/server/docker/opentelemetry/otel-collector-config.yaml
@@ -1,0 +1,41 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    const_labels:
+      label1: value1
+
+  zipkin:
+    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
+    format: proto
+
+  otlp:
+    endpoint: jaeger-all-in-one:4317
+    tls:
+      insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [zipkin, otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]

--- a/server/docker/opentelemetry/prometheus.yaml
+++ b/server/docker/opentelemetry/prometheus.yaml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'otel-collector'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['otel-collector:8889']
+      - targets: ['otel-collector:8888']


### PR DESCRIPTION
Based on the Demo example from [open-telemetry/opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib), this PR updates the example to show how to deploy the collector in Agent mode. 

> The agent collector deployment pattern consists of applications — [instrumented](https://opentelemetry.io/docs/instrumentation/) with an OpenTelemetry SDK using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/) — or other [collector](https://opentelemetry.io/docs/collector/)s (using the OTLP exporter) that send telemetry signals to a collector instance running with the application or on the same host as the application (such as a sidecar or a daemonset).
> 
> Each client-side SDK or downstream collector is configured with a collector location:
> 
>
> ![otel-agent-sdk](https://github.com/xebia-functional/xef/assets/720923/26764516-d07c-4375-8b4f-f1ca087a5f9b)
>
> Decentralized collector deployment concept
> In the app, the SDK is configured to send OTLP data to a collector.
> The collector is configured to send telemetry data to one or more backends.

[Ref docs](https://opentelemetry.io/docs/collector/deployment/agent/)

The `Animal.kt` client uses the opentelemetry library for instrumentation and for sending telemetry data to the opentelemetry collector.

This example presents the typical flow of observability data where multiple OpenTelemetry Collectors can be deployed.

```mermaid
graph TD;
    ClientA-->Collector;
    ClientB-->Collector;
    Collector-->Jaeger;
    Collector-->Zipkin;
    Collector-->Prometheus;
```

- Clients send data directly to the OpenTelemetry Collector
- The OpenTelemetry Collector Collector then sends the data to the appropriate backend. In the example Jaeger, Zipkin, and Prometheus.

The example uses `docker-compose`. To run the demo, switch to the `server/docker/opentelemetry` folder and run:

```shell
docker compose up -d
```

Docker should expose the following backends:

- Jaeger at http://0.0.0.0:16686
- Zipkin at http://0.0.0.0:9411
- Prometheus at http://0.0.0.0:9090