### PR TITLE
Allow custom mappings for different models

### DIFF
--- a/server/src/main/kotlin/com/xebia/functional/xef/server/http/client/ModelUriAdapter.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/http/client/ModelUriAdapter.kt
@@ -1,0 +1,79 @@
+package com.xebia.functional.xef.server.http.client
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.util.*
+import io.ktor.util.pipeline.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class ModelUriAdapter
+internal constructor(private val urlMap: Map<OpenAIPathType, Map<String, String>>) {
+
+  val logger = KotlinLogging.logger {}
+
+  fun isDefined(path: OpenAIPathType): Boolean = urlMap.containsKey(path)
+
+  fun findPath(path: OpenAIPathType, model: String): String? = urlMap[path]?.get(model)
+
+  companion object : HttpClientPlugin<ModelUriAdapterBuilder, ModelUriAdapter> {
+
+    override val key: AttributeKey<ModelUriAdapter> = AttributeKey("ModelAuthAdapter")
+
+    override fun prepare(block: ModelUriAdapterBuilder.() -> Unit): ModelUriAdapter =
+      ModelUriAdapterBuilder().apply(block).build()
+
+    override fun install(plugin: ModelUriAdapter, scope: HttpClient) {
+      installModelAuthAdapter(plugin, scope)
+    }
+
+    private fun readModelFromRequest(originalRequest: OutgoingContent.ByteArrayContent?): String? {
+      val requestBody = originalRequest?.bytes()?.toString(Charsets.UTF_8)
+      val json = requestBody?.let { Json.decodeFromString<JsonObject>(it) }
+      return json?.get("model")?.jsonPrimitive?.content
+    }
+
+    private fun installModelAuthAdapter(plugin: ModelUriAdapter, scope: HttpClient) {
+      val adaptAuthRequestPhase = PipelinePhase("ModelAuthAdaptRequest")
+      scope.sendPipeline.insertPhaseAfter(HttpSendPipeline.State, adaptAuthRequestPhase)
+      scope.sendPipeline.intercept(adaptAuthRequestPhase) { content ->
+        val originalPath = OpenAIPathType.from(context.url.encodedPath) ?: return@intercept
+        if (plugin.isDefined(originalPath)) {
+          val originalRequest = content as? OutgoingContent.ByteArrayContent
+          if (originalRequest == null) {
+            plugin.logger.warn {
+              """
+                        |Can't adapt the model auth. 
+                        |The body type is: ${content::class}, with Content-Type: ${context.contentType()}.
+                        |
+                        |If you expect serialized body, please check that you have installed the corresponding 
+                        |plugin(like `ContentNegotiation`) and set `Content-Type` header."""
+                .trimMargin()
+            }
+            return@intercept
+          }
+          val model = readModelFromRequest(originalRequest)
+          val newURL = model?.let { plugin.findPath(originalPath, it) }
+          if (newURL == null) {
+            plugin.logger.info {
+              "Model auth didn't found a new url for path $originalPath and model $model"
+            }
+          } else {
+            val baseBuilder = URLBuilder(newURL).build()
+            context.url.set(
+              scheme = baseBuilder.protocol.name,
+              host = baseBuilder.host,
+              port = baseBuilder.port,
+              path = baseBuilder.encodedPath
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/http/client/ModelUriAdapterBuilder.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/http/client/ModelUriAdapterBuilder.kt
@@ -1,0 +1,17 @@
+package com.xebia.functional.xef.server.http.client
+
+class ModelUriAdapterBuilder {
+
+  private var pathMap: Map<OpenAIPathType, Map<String, String>> = LinkedHashMap()
+
+  fun setPathMap(pathMap: Map<OpenAIPathType, Map<String, String>>) {
+    this.pathMap = pathMap
+  }
+
+  fun addToPath(path: OpenAIPathType, vararg modelUriPaths: Pair<String, String>) {
+    val newPathTypeMap = mapOf(*modelUriPaths.map { Pair(it.first, it.second) }.toTypedArray())
+    this.pathMap += mapOf(path to newPathTypeMap)
+  }
+
+  internal fun build(): ModelUriAdapter = ModelUriAdapter(pathMap)
+}

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/http/client/OpenAIPathType.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/http/client/OpenAIPathType.kt
@@ -1,0 +1,15 @@
+package com.xebia.functional.xef.server.http.client
+
+enum class OpenAIPathType(val value: String) {
+  CHAT("/v1/chat/completions"),
+  EMBEDDINGS("/v1/embeddings"),
+  FINE_TUNING("/v1/fine_tuning/jobs"),
+  FILES("/v1/files"),
+  IMAGES("/v1/images/generations"),
+  MODELS("/v1/models"),
+  MODERATION("/v1/moderations");
+
+  companion object {
+    fun from(v: String): OpenAIPathType? = entries.find { it.value == v }
+  }
+}


### PR DESCRIPTION
# Model URI Adapter

This PR adds support for different models based on the path and model in the request. With this, you can quickly start a new endpoint and redirect all the traffic for a particular path (chat completion, embeddings, ...) to a specific endpoint instead of OpenAI.

## Example 1

Let's say we want to use a custom model for the embeddings. 

### 1. Prepare the embedding endpoint

One of the easiest ways to do it is to use [huggingface/text-embeddings-inference](https://github.com/huggingface/text-embeddings-inference).

> Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.

One of the tools that TEI provides is a multi-purpose docker image to ramp up a server. Since TEI supports the Bert model, we can use [BAAI/llm-embedder](https://huggingface.co/BAAI/llm-embedder). Starting this model locally is as easy as running the following command:

```shell
docker run -p 9090:80 -v /tmp/gf-data:/data --pull always ghcr.io/huggingface/text-embeddings-inference:cpu-0.3.0 --model-id BAAI/llm-embedder --revision main
```

- `/tmp/gf-data` is a shared volume with the Docker container to avoid downloading weights every run
- `text-embeddings-inference:cpu-0.3.0` uses the Docker image for running locally in CPU. We have [others available](https://github.com/huggingface/text-embeddings-inference#docker-images)
- `BAAI/llm-embedder` is the model
- `main` is the repo revision. It can be a tag and a commit also.

The Docker image will bump a server with a series of endpoints. One of them is fully compatible with the OpenAI API:

* https://huggingface.github.io/text-embeddings-inference/#/Text%20Embeddings%20Inference/openai_embed

### 2. Install the Ktor client plugin

The second step is to install the Ktor client plugin to redirect requests to the local embedding endpoint. We want to redirect all the requests to `"/v1/embeddings"` with the model `BAAI/llm-embedder` to the recently created endpoint:

* http://localhost:9090/openai

To install the plugin and configure the Ktor client plugin, we need to add the following code in the client's initialization:

https://github.com/xebia-functional/xef/blob/21f0f4a0b8b79a2a5ebe1ddd6487e38ef27dac34/server/src/main/kotlin/com/xebia/functional/xef/server/Server.kt#L56-L63

```kotlin
install(com.xebia.functional.xef.server.http.client.ModelUriAdapter) {
  addToPath(
    com.xebia.functional.xef.server.http.client.OpenAIPathType.EMBEDDINGS,
    "BAAI/llm-embedder" to "http://localhost:9090/openai"
  )
}
```

## Example 2

Redirecting chat completion requests is quite similar. Let's imagine we have a local proxy running a `gpt-3.5-turbo` in the following address:

* http://localhost:8080/chat/completions

The necessary code for redirecting the requests will be:

```kotlin
install(com.xebia.functional.xef.server.http.client.ModelUriAdapter) {
  addToPath(
    com.xebia.functional.xef.server.http.client.OpenAIPathType.CHAT,
    "gpt-3.5-turbo" to "http://localhost:8080/chat/completions"
  )
}
```

## Notes

Future improvements could use headers as input for the URI/model map. Also, the map is currently set in code, but we could use DB to fill that information.

This works as a reverse proxy without modifying the request/response. The next step will be to have a new component that could adapt requests/responses to APIs that are not OpenAI compatible (like MLflow). The full interaction is represented in the following diagram.

```mermaid
sequenceDiagram
    Client->>ModelUriAdapter: Path + Model
    ModelUriAdapter->>ModelReqResAdapter: Request
    ModelReqResAdapter->>Model: Request
    Model->>ModelReqResAdapter: Response
    ModelReqResAdapter->>Client: Response
```



