### PR TITLE
[Fix] - Update deprecated detekt source setter

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,7 +30,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/filesystem/build.gradle.kts
+++ b/filesystem/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies { detektPlugins(project(":detekt-rules")) }
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/gpt4all-kotlin/build.gradle.kts
+++ b/gpt4all-kotlin/build.gradle.kts
@@ -20,7 +20,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/integrations/gcp/build.gradle.kts
+++ b/integrations/gcp/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies { detektPlugins(project(":detekt-rules")) }
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/integrations/lucene/build.gradle.kts
+++ b/integrations/lucene/build.gradle.kts
@@ -18,7 +18,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/main/kotlin")
+    source.setFrom(files("src/main/kotlin"))
     config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/integrations/mlflow/build.gradle.kts
+++ b/integrations/mlflow/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies { detektPlugins(project(":detekt-rules")) }
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/integrations/opentelemetry/build.gradle.kts
+++ b/integrations/opentelemetry/build.gradle.kts
@@ -19,7 +19,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/main/kotlin")
+    source.setFrom(files("src/main/kotlin"))
     config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/integrations/pdf/build.gradle.kts
+++ b/integrations/pdf/build.gradle.kts
@@ -17,7 +17,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/main/kotlin")
+    source.setFrom(files("src/main/kotlin"))
     config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/integrations/postgresql/build.gradle.kts
+++ b/integrations/postgresql/build.gradle.kts
@@ -18,7 +18,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/main/kotlin")
+    source.setFrom(files("src/main/kotlin"))
     config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/integrations/sql/build.gradle.kts
+++ b/integrations/sql/build.gradle.kts
@@ -17,7 +17,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/main/kotlin")
+    source.setFrom(files("src/main/kotlin"))
     config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies { detektPlugins(project(":detekt-rules")) }
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/openai/build.gradle.kts
+++ b/openai/build.gradle.kts
@@ -26,7 +26,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/reasoning/build.gradle.kts
+++ b/reasoning/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies { detektPlugins(project(":detekt-rules")) }
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../config/detekt/detekt.yml")
     autoCorrect = true
 }

--- a/tokenizer/build.gradle.kts
+++ b/tokenizer/build.gradle.kts
@@ -20,7 +20,7 @@ java {
 
 detekt {
     toolVersion = "1.23.1"
-    source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
+    source.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
     config.setFrom("../config/detekt/detekt.yml")
     autoCorrect = true
 }


### PR DESCRIPTION
This PR remove all this warning messages:

```'setter for source: ConfigurableFileCollection' is deprecated. Setter will be removed in a future release. Use `from` or `setFrom` instead.```

