### PR TITLE
Replace host, port, and database properties by url in VectorStore configuration

### DIFF
--- a/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/store/migrations/PsqlVectorStoreConfig.kt
+++ b/integrations/postgresql/src/main/kotlin/com/xebia/functional/xef/store/migrations/PsqlVectorStoreConfig.kt
@@ -7,7 +7,7 @@ import org.flywaydb.core.api.configuration.FluentConfiguration
 import org.flywaydb.core.api.output.MigrateResult
 
 class PsqlVectorStoreConfig(
-  val uri: String,
+  val url: String,
   val driver: String,
   val user: String,
   val password: String,
@@ -18,7 +18,7 @@ class PsqlVectorStoreConfig(
     withContext(Dispatchers.IO) {
       val migration: FluentConfiguration = Flyway.configure()
         .dataSource(
-          uri,
+          url,
           user,
           password
         )

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/PSQLVectorStoreConfig.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/PSQLVectorStoreConfig.kt
@@ -16,9 +16,7 @@ import org.slf4j.Logger
 
 @Serializable
 class PSQLVectorStoreConfig(
-  val host: String,
-  val port: Int,
-  val database: String,
+  val url: String,
   val driver: String,
   val user: String,
   val password: String,
@@ -26,24 +24,14 @@ class PSQLVectorStoreConfig(
   val vectorSize: Int
 ) : VectorStoreConfig {
 
-  fun getUrl(): String = "jdbc:postgresql://$host:$port/$database"
-
   override suspend fun getVectorStoreService(logger: Logger): PostgresVectorStoreService {
-    val vectorStoreHikariDataSource =
-      RepositoryService.getHikariDataSource(getUrl(), user, password)
+    val vectorStoreHikariDataSource = RepositoryService.getHikariDataSource(url, user, password)
     return PostgresVectorStoreService(toPGVectorStoreConfig(), logger, vectorStoreHikariDataSource)
   }
 
   private fun toPGVectorStoreConfig() =
     PostgreSQLXef.PGVectorStoreConfig(
-      dbConfig =
-        PostgreSQLXef.DBConfig(
-          host = host,
-          port = port,
-          database = database,
-          user = user,
-          password = password
-        ),
+      dbConfig = PostgreSQLXef.DBConfig(url = url, user = user, password = password),
       collectionName = collectionName,
       vectorSize = vectorSize
     )
@@ -61,9 +49,7 @@ class PSQLVectorStoreConfig(
 
     private fun PSQLVectorStoreConfig.toPSQLConfig(): PsqlVectorStoreConfig =
       PsqlVectorStoreConfig(
-        host = this.host,
-        port = this.port,
-        database = this.database,
+        url = this.url,
         driver = this.driver,
         user = this.user,
         password = this.password,

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/PSQLVectorStoreConfig.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/db/psql/PSQLVectorStoreConfig.kt
@@ -37,6 +37,20 @@ class PSQLVectorStoreConfig(
     )
 
   companion object {
+    operator fun invoke(
+      host: String,
+      port: Int,
+      database: String,
+      driver: String,
+      user: String,
+      password: String,
+      collectionName: String,
+      vectorSize: Int
+    ): PSQLVectorStoreConfig {
+      val url = "jdbc:postgresql://${host}:${port}/${database}"
+      return PSQLVectorStoreConfig(url, driver, user, password, collectionName, vectorSize)
+    }
+
     @OptIn(ExperimentalSerializationApi::class)
     suspend fun load(configNamespace: String, config: Config?): PSQLVectorStoreConfig =
       withContext(Dispatchers.IO) {

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresVectorStoreService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresVectorStoreService.kt
@@ -14,13 +14,7 @@ import kotlinx.uuid.generateUUID
 import org.slf4j.Logger
 
 object PostgreSQLXef {
-  data class DBConfig(
-    val host: String,
-    val port: Int,
-    val database: String,
-    val user: String,
-    val password: String
-  )
+  data class DBConfig(val url: String, val user: String, val password: String)
 
   data class PGVectorStoreConfig(
     val dbConfig: DBConfig,


### PR DESCRIPTION
The vector store configuration class requires the host, port, and database name to build the URL. This approach is more flexible for cases where the URI is defined differently, like databases stored in Google Cloud SQL.