### PR TITLE
Change detekt.yml file location for open-ai-clien module

### DIFF
--- a/openai-client/client/build.gradle.kts
+++ b/openai-client/client/build.gradle.kts
@@ -27,7 +27,7 @@ java {
 detekt {
     toolVersion = "1.23.1"
     source = files("src/commonMain/kotlin", "src/jvmMain/kotlin")
-    config.setFrom("../config/detekt/detekt.yml")
+    config.setFrom("../../config/detekt/detekt.yml")
     autoCorrect = true
 }
 


### PR DESCRIPTION
This pull request fixes an issue with the detekt tool in the `main` branch because the `xef-openai-client` module has an additional folder, causing the relative URL to `detekt.yml` to point to an invalid location.