### PR TITLE
[FIX] - Gradle problem in buildAndTestSinglep and buildAndTestMultip

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,10 +57,6 @@ fun includeOrNotModulesToCommand(modules: List<String>, platform: String, includ
     }.toTypedArray()
 }
 
-fun buildExcludeOptions(modules: List<String>): Array<String> {
-  return modules.flatMap { module -> listOf("-x", ":$module:build") }.toTypedArray()
-}
-
 fun getGradleCommand(platform: String): String {
   return if (platform == "mingwX64") "gradlew.bat" else "./gradlew"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,59 +15,58 @@ allprojects {
     group = property("project.group").toString()
 }
 
-fun isMultiplatformModule(project: Project): Boolean {
-  val kotlinPluginId = "libs.plugins.kotlin.multiplatform"
-  return project.buildFile.readText().contains(kotlinPluginId)
-}
-
-val multiPlatformModules = project.subprojects.filter { isMultiplatformModule(it) }.map { it.name }
-
-enum class ModuleType { SINGLEPLATFORM, MULTIPLATFORM }
-
-fun Project.configureBuildAndTestTask(
-  taskName: String,
-  moduleType: ModuleType,
-  multiPlatformModules: List<String>
-) {
+fun Project.configureBuildAndTestTask(taskName: String, moduleType: ModulePlatformType) {
   val platform: String by extra
+  val multiPlatformModules = project.subprojects.filter { isMultiPlatformModule(it) }.map { it.name }
+
   tasks.register(taskName) {
+    val gradleCommand = getGradleCommand(platform)
+
+    doFirst {
+        project.exec {commandLine(gradleCommand, "spotlessCheck") }
+    }
+
     doLast {
-      val gradleCommand = getGradleCommand(platform)
-      project.exec {
-        commandLine(gradleCommand, "spotlessCheck")
-      }
-      project.exec {
-        when (moduleType) {
-          ModuleType.SINGLEPLATFORM -> {
-            commandLine(gradleCommand, "build", *buildExcludeOptions(multiPlatformModules))
+      when (moduleType) {
+          ModulePlatformType.SINGLE -> {
+              val excludedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, false)
+              println("modulesToExclude: ${excludedModules.toList()}")
+              project.exec { commandLine(gradleCommand, "build", *excludedModules) }
           }
-          ModuleType.MULTIPLATFORM -> {
-            multiPlatformModules.forEach { module ->
-              commandLine(gradleCommand, ":$module:${platform}Test")
-            }
+
+          ModulePlatformType.MULTI -> {
+            val includedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, true)
+              println("modulesToInclude: ${includedModules.toList()}")
+            project.exec { commandLine(gradleCommand, *includedModules) }
           }
-        }
       }
     }
   }
 }
 
+enum class ModulePlatformType { SINGLE, MULTI }
+
+fun isMultiPlatformModule(project: Project): Boolean {
+    val kotlinPluginId = "libs.plugins.kotlin.multiplatform"
+    return project.buildFile.readText().contains(kotlinPluginId)
+}
+
+fun includeOrNotModulesToCommand(modules: List<String>, platform: String, include: Boolean): Array<String> {
+    return modules.flatMap {
+        when (include) {
+            true -> listOf(":$it:${platform}Test")
+            false -> listOf("-x", ":$it:build")
+        }
+    }.toTypedArray()
+}
+
 fun buildExcludeOptions(modules: List<String>): Array<String> {
-  return modules.flatMap { listOf("-x", ":$it:build") }.toTypedArray()
+  return modules.flatMap { module -> listOf("-x", ":$module:build") }.toTypedArray()
 }
 
 fun getGradleCommand(platform: String): String {
   return if (platform == "mingwX64") "gradlew.bat" else "./gradlew"
 }
 
-configureBuildAndTestTask(
-  "buildAndTestMultip",
-  ModuleType.MULTIPLATFORM,
-  multiPlatformModules
-)
-
-configureBuildAndTestTask(
-  "buildAndTestSinglep",
-  ModuleType.SINGLEPLATFORM,
-  multiPlatformModules
-)
+configureBuildAndTestTask("buildAndTestMultip", ModulePlatformType.MULTI)
+configureBuildAndTestTask("buildAndTestSinglep", ModulePlatformType.SINGLE)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,17 +28,14 @@ fun Project.configureBuildAndTestTask(taskName: String, moduleType: ModulePlatfo
 
     doLast {
       when (moduleType) {
-          ModulePlatformType.SINGLE -> {
-              val excludedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, false)
-              println("modulesToExclude: ${excludedModules.toList()}")
-              project.exec { commandLine(gradleCommand, "build", *excludedModules) }
-          }
-
-          ModulePlatformType.MULTI -> {
-            val includedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, true)
-              println("modulesToInclude: ${includedModules.toList()}")
-            project.exec { commandLine(gradleCommand, *includedModules) }
-          }
+        ModulePlatformType.SINGLE -> {
+          val excludedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, false)
+          project.exec { commandLine(gradleCommand, "build", *excludedModules) }
+        }
+        ModulePlatformType.MULTI -> {
+          val includedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, true)
+          project.exec { commandLine(gradleCommand, *includedModules) }
+        }
       }
     }
   }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/AutoClose.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/AutoClose.kt
@@ -9,7 +9,7 @@ import io.ktor.utils.io.core.*
  * dependencies
  */
 interface AutoClose : AutoCloseable {
-  fun <A : AutoCloseable> autoClose(autoCloseable: A): A
+           fun <A : AutoCloseable> autoClose(autoCloseable: A): A
 }
 
 /** DSL method to use AutoClose */

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/AutoClose.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/AutoClose.kt
@@ -9,7 +9,7 @@ import io.ktor.utils.io.core.*
  * dependencies
  */
 interface AutoClose : AutoCloseable {
-           fun <A : AutoCloseable> autoClose(autoCloseable: A): A
+  fun <A : AutoCloseable> autoClose(autoCloseable: A): A
 }
 
 /** DSL method to use AutoClose */


### PR DESCRIPTION
Fix the problem with Gradle executing more than two exec commands.

A [Gradle Exec task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Exec.html) will only run the last ‘commandLine’ defined inside its block. Putting multiple entries inside its block will not run multiple commands.

Before we only execute the xef-tokenizer module due to this behaviour. Now we execute all the modules.

I want to continue investigating if we can reduce times.