### PR TITLE
Add required configuration to publish xef-evaluator module

### DIFF
--- a/evaluator/build.gradle.kts
+++ b/evaluator/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     id(libs.plugins.kotlin.jvm.get().pluginId)
     id(libs.plugins.kotlinx.serialization.get().pluginId)
+    alias(libs.plugins.arrow.gradle.publish)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.semver.gradle)
     alias(libs.plugins.spotless)
 }
 
@@ -14,6 +17,14 @@ java {
 
 dependencies {
     api(libs.kotlinx.serialization.json)
+    detektPlugins(project(":detekt-rules"))
+}
+
+detekt {
+    toolVersion = "1.23.1"
+    source.setFrom(files("src/main/kotlin"))
+    config.setFrom("../config/detekt/detekt.yml")
+    autoCorrect = true
 }
 
 spotless {


### PR DESCRIPTION
This pull request adds some required configuration to the Gradle build to publish the artifacts in Maven