### PR TITLE
Fix response streaming using HttpStatement

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/Conversation.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/Conversation.kt
@@ -1,7 +1,6 @@
 package com.xebia.functional.xef.conversation
 
 import com.xebia.functional.openai.apis.ChatApi
-import com.xebia.functional.openai.apis.EmbeddingsApi
 import com.xebia.functional.openai.apis.ImagesApi
 import com.xebia.functional.openai.models.CreateChatCompletionRequestModel
 import com.xebia.functional.openai.models.CreateImageRequest
@@ -12,7 +11,6 @@ import com.xebia.functional.xef.llm.*
 import com.xebia.functional.xef.metrics.Metric
 import com.xebia.functional.xef.prompt.Prompt
 import com.xebia.functional.xef.store.ConversationId
-import com.xebia.functional.xef.store.LocalVectorStore
 import com.xebia.functional.xef.store.VectorStore
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmSynthetic
@@ -25,7 +23,7 @@ import kotlinx.uuid.generateUUID
 class Conversation
 @JvmOverloads
 constructor(
-  val store: VectorStore = LocalVectorStore(fromEnvironment { baseUrl -> EmbeddingsApi(baseUrl) }),
+  val store: VectorStore = VectorStore.EMPTY,
   val metric: Metric = Metric.EMPTY,
   val conversationId: ConversationId? = ConversationId(UUID.generateUUID().toString())
 ) {
@@ -96,9 +94,8 @@ constructor(
   ): Flow<String> = chat.promptStreaming(prompt, this@Conversation)
 
   @AiDsl
-  fun ChatApi.promptStreaming(
-    prompt: Prompt<CreateChatCompletionRequestModel>
-  ): Flow<String> = promptStreaming(prompt, this@Conversation)
+  fun ChatApi.promptStreaming(prompt: Prompt<CreateChatCompletionRequestModel>): Flow<String> =
+    promptStreaming(prompt, this@Conversation)
 
   /**
    * Run a [prompt] describes the images you want to generate within the context of [Conversation].
@@ -120,7 +117,7 @@ constructor(
 
     @JvmSynthetic
     suspend operator fun <A> invoke(
-      store: VectorStore = LocalVectorStore(fromEnvironment { baseUrl -> EmbeddingsApi(baseUrl) }),
+      store: VectorStore = VectorStore.EMPTY,
       metric: Metric = Metric.EMPTY,
       conversationId: ConversationId? = ConversationId(UUID.generateUUID().toString()),
       block: suspend Conversation.() -> A

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/Conversation.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/Conversation.kt
@@ -90,14 +90,15 @@ constructor(
   ): Flow<StreamedFunction<A>> = chat.promptStreaming(prompt, this@Conversation, serializer())
 
   @AiDsl
-  fun promptStreaming(
+  suspend fun promptStreaming(
     prompt: Prompt<CreateChatCompletionRequestModel>,
     chat: ChatApi = fromEnvironment(::ChatApi)
   ): Flow<String> = chat.promptStreaming(prompt, this@Conversation)
 
   @AiDsl
-  fun ChatApi.promptStreaming(prompt: Prompt<CreateChatCompletionRequestModel>): Flow<String> =
-    promptStreaming(prompt, this@Conversation)
+  suspend fun ChatApi.promptStreaming(
+    prompt: Prompt<CreateChatCompletionRequestModel>
+  ): Flow<String> = promptStreaming(prompt, this@Conversation)
 
   /**
    * Run a [prompt] describes the images you want to generate within the context of [Conversation].

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/Conversation.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/conversation/Conversation.kt
@@ -90,13 +90,13 @@ constructor(
   ): Flow<StreamedFunction<A>> = chat.promptStreaming(prompt, this@Conversation, serializer())
 
   @AiDsl
-  suspend fun promptStreaming(
+  fun promptStreaming(
     prompt: Prompt<CreateChatCompletionRequestModel>,
     chat: ChatApi = fromEnvironment(::ChatApi)
   ): Flow<String> = chat.promptStreaming(prompt, this@Conversation)
 
   @AiDsl
-  suspend fun ChatApi.promptStreaming(
+  fun ChatApi.promptStreaming(
     prompt: Prompt<CreateChatCompletionRequestModel>
   ): Flow<String> = promptStreaming(prompt, this@Conversation)
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/Chat.kt
@@ -38,15 +38,15 @@ fun ChatApi.promptStreaming(
         buffer.append(content)
       }
       content
-    }.onEach {
-      emit(it)
     }
+    .onEach { emit(it) }
     .onCompletion {
       val aiResponseMessage = assistant(buffer.toString())
       val newMessages = prompt.messages + listOf(aiResponseMessage)
       newMessages.addToMemory(scope, prompt.configuration.messagePolicy.addMessagesToConversation)
       buffer.clear()
-    }.collect()
+    }
+    .collect()
 }
 
 @AiDsl

--- a/examples/src/main/kotlin/com/xebia/functional/xef/conversation/streaming/SimpleStreaming.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/conversation/streaming/SimpleStreaming.kt
@@ -1,0 +1,22 @@
+package com.xebia.functional.xef.conversation.streaming
+
+import ai.xef.openai.StandardModel
+import com.xebia.functional.openai.apis.EmbeddingsApi
+import com.xebia.functional.openai.models.CreateChatCompletionRequestModel
+import com.xebia.functional.xef.conversation.Conversation
+import com.xebia.functional.xef.llm.fromEnvironment
+import com.xebia.functional.xef.metrics.LogsMetric
+import com.xebia.functional.xef.prompt.Prompt
+import com.xebia.functional.xef.store.LocalVectorStore
+
+suspend fun main() {
+  val model = StandardModel(CreateChatCompletionRequestModel.gpt_3_5_turbo)
+
+  val scope = Conversation(LocalVectorStore(fromEnvironment(::EmbeddingsApi)), LogsMetric())
+
+  scope
+    .promptStreaming(
+      Prompt(model, "Create a 1000 word essay about Mars"),
+    )
+    .collect { element -> print(element) }
+}

--- a/examples/src/main/resources/logback.xml
+++ b/examples/src/main/resources/logback.xml
@@ -12,8 +12,8 @@
         </encoder>
     </appender>
 
-    <root level="error">
-        <appender-ref ref="NOOP"/>
+    <root level="trace">
+        <appender-ref ref="STDOUT"/>
     </root>
 
     <logger name="com.xebia.functional.xef" level="debug">

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlin = "1.9.21"
 kotlinx-json = "1.6.2"
 kotlinx-datetime = "0.4.1"
 ktor = "2.3.7"
+ktor-logging = "0.4.0"
 spotless = "6.23.3"
 okio = "3.7.0"
 kotest = "5.8.0"
@@ -75,6 +76,7 @@ ktor-server-resources = { module = "io.ktor:ktor-server-resources", version.ref 
 ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
 ktor-server-request-validation = { module = "io.ktor:ktor-server-request-validation", version.ref = "ktor" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+ktor-logging = { module = "com.koriit.kotlin:ktor-logging", version.ref = "ktor-logging" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 okio-nodefilesystem = { module = "com.squareup.okio:okio-nodefilesystem", version.ref = "okio" }

--- a/openai-client/client/src/commonMain/kotlin/com/xebia/functional/openai/infrastructure/ApiClient.kt
+++ b/openai-client/client/src/commonMain/kotlin/com/xebia/functional/openai/infrastructure/ApiClient.kt
@@ -4,6 +4,7 @@ import com.xebia.functional.openai.auth.*
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.FormDataContent
@@ -30,6 +31,7 @@ open class ApiClient(val baseUrl: String) {
     val clientConfig: (HttpClientConfig<*>) -> Unit by lazy {
       {
         it.install(ContentNegotiation) { json(jsonBlock) }
+        it.install(HttpTimeout)
         httpClientConfig?.invoke(it)
       }
     }

--- a/openai-client/client/src/commonMain/kotlin/com/xebia/functional/openai/infrastructure/ApiClient.kt
+++ b/openai-client/client/src/commonMain/kotlin/com/xebia/functional/openai/infrastructure/ApiClient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.MultiPartFormDataContent
@@ -16,6 +17,8 @@ import io.ktor.http.*
 import io.ktor.http.content.PartData
 import io.ktor.serialization.kotlinx.json.json
 import kotlin.Unit
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 import kotlinx.serialization.json.Json
 
 open class ApiClient(val baseUrl: String) {
@@ -167,6 +170,10 @@ open class ApiClient(val baseUrl: String) {
       this.url {
         contentType(ContentType.Application.Json)
         this.takeFrom(URLBuilder(baseUrl))
+        timeout {
+          requestTimeoutMillis = 60.seconds.toLong(DurationUnit.MILLISECONDS)
+          socketTimeoutMillis = 60.seconds.toLong(DurationUnit.MILLISECONDS)
+        }
         appendPath(requestConfig.path.trimStart('/').split('/'))
         requestConfig.query.forEach { query ->
           query.value.forEach { value -> parameter(query.key, value) }


### PR DESCRIPTION
The streamed response was fully consumed in memory first because of the call to `response.body`. Instead, we use the recommended ktor docs:

https://ktor.io/docs/response.html#streaming

> When you call the HttpResponse.body function to get a body, Ktor processes a response in memory and returns a full response body. If you need to get chunks of a response sequentially instead of waiting for the entire response, use HttpStatement with scoped [execute](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.statement/-http-statement/execute.html) block.

Additionally, the stream was being folded before emission in the `Chat` interface, which a completion handler and a StringBuilder have replaced to accumulate the final assistant response.

This PR includes also a fix for conversations by default using vector stores that are empty

Run included `SimpleStreaming` example to see the correct behavior of each word being streamed as the AI replies.