### PR TITLE
Fixes OpenTelemetry tracing scoping

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
@@ -4,7 +4,7 @@ import com.xebia.functional.openai.models.CreateChatCompletionResponse
 import com.xebia.functional.xef.conversation.Conversation
 import com.xebia.functional.xef.prompt.Prompt
 
-fun CreateChatCompletionResponse.addMetrics(
+suspend fun CreateChatCompletionResponse.addMetrics(
   conversation: Conversation
 ): CreateChatCompletionResponse {
   conversation.metric.parameter("model", model)
@@ -15,7 +15,7 @@ fun CreateChatCompletionResponse.addMetrics(
   return this
 }
 
-fun <T> Prompt<T>.addMetrics(conversation: Conversation) {
+suspend fun <T> Prompt<T>.addMetrics(conversation: Conversation) {
   conversation.metric.parameter(
     "number-of-messages",
     "${messages.size} (${messages.map { it.completionRole().value.firstOrNull() ?: "" }.joinToString("-")})"

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/LogsMetric.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/LogsMetric.kt
@@ -38,11 +38,11 @@ class LogsMetric : Metric {
     return output
   }
 
-  override fun event(message: String) {
+  override suspend fun event(message: String) {
     logger.info { "${writeIndent(numberOfBlocks.get())}|-- $message" }
   }
 
-  override fun parameter(key: String, value: String) {
+  override suspend fun parameter(key: String, value: String) {
     logger.info { "${writeIndent(numberOfBlocks.get())}|-- $key = $value" }
   }
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/Metric.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/Metric.kt
@@ -7,9 +7,9 @@ interface Metric {
 
   suspend fun <A, T> promptSpan(prompt: Prompt<T>, block: suspend Metric.() -> A): A
 
-  fun event(message: String)
+  suspend fun event(message: String)
 
-  fun parameter(key: String, value: String)
+  suspend fun parameter(key: String, value: String)
 
   companion object {
     val EMPTY: Metric =
@@ -22,9 +22,9 @@ interface Metric {
           block: suspend Metric.() -> A
         ): A = block()
 
-        override fun event(message: String) {}
+        override suspend fun event(message: String) {}
 
-        override fun parameter(key: String, value: String) {}
+        override suspend fun parameter(key: String, value: String) {}
       }
   }
 }

--- a/examples/src/main/kotlin/com/xebia/functional/xef/conversation/conversations/Animal.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/conversation/conversations/Animal.kt
@@ -19,10 +19,11 @@ data class Invention(val name: String, val inventor: String, val year: Int, val 
 suspend fun main() {
   // This example contemplate the case of using OpenTelemetry for metrics
   // To run the example with OpenTelemetry, you can execute the following commands:
-  //  - # docker compose-up server/docker/opentelemetry
+  //  - # cd server/docker/opentelemetry
+  //  - # docker-compose up
 
   Conversation(
-    // metric = com.xebia.functional.xef.opentelemetry.OpenTelemetryMetric()
+    //    metric = com.xebia.functional.xef.opentelemetry.OpenTelemetryMetric(),
     metric = com.xebia.functional.xef.metrics.LogsMetric()
   ) {
     metric.customSpan("Animal Example") {

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryMetric.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryMetric.kt
@@ -16,18 +16,16 @@ class OpenTelemetryMetric(
     state.span(name) { block() }
 
   override suspend fun <A, T> promptSpan(prompt: Prompt<T>, block: suspend Metric.() -> A): A =
-    state.span("Prompt: ${prompt.messages.lastOrNull()?.contentAsString() ?: "empty"}") {
-      with(it) {
-        setAttribute("last-message", prompt.messages.lastOrNull()?.contentAsString() ?: "empty")
-      }
+    state.span("Prompt: ${prompt.messages.lastOrNull()?.contentAsString() ?: "empty"}") { span ->
+      span.setAttribute("last-message", prompt.messages.lastOrNull()?.contentAsString() ?: "empty")
       block()
     }
 
-  override fun event(message: String) {
+  override suspend fun event(message: String) {
     state.event(message)
   }
 
-  override fun parameter(key: String, value: String) {
+  override suspend fun parameter(key: String, value: String) {
     state.setAttribute(key, value)
   }
 

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 
 class OpenTelemetryState(val tracer: Tracer) {
 
-  suspend fun <A> span(name: String, block: suspend OpenTelemetryState.(Span) -> A): A {
+  suspend fun <A> span(name: String, block: suspend (Span) -> A): A {
     val parentOrRoot = currentCoroutineContext().getOpenTelemetryContext()
 
     val currentSpan = tracer.spanBuilder(name).setParent(parentOrRoot).startSpan()

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
@@ -3,47 +3,35 @@ package com.xebia.functional.xef.opentelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
 
 class OpenTelemetryState(val tracer: Tracer) {
 
-  val contextSpans = mutableListOf<Context>()
-
   suspend fun <A> span(name: String, block: suspend OpenTelemetryState.(Span) -> A): A {
-    val currentContext = contextSpans.lastOrNull()
+    val parentOrRoot = currentCoroutineContext().getOpenTelemetryContext()
 
-    val currentSpan =
-      currentContext?.let {
-        val span = tracer.spanBuilder(name).setParent(it).startSpan()
-        span.makeCurrent()
-        contextSpans.add(Context.current())
-        span
+    val currentSpan = tracer.spanBuilder(name).setParent(parentOrRoot).startSpan()
+
+    return try {
+      withContext(currentSpan.asContextElement()) {
+        currentSpan.makeCurrent().use { block(currentSpan) }
       }
-        ?: run {
-          val span = tracer.spanBuilder(name).startSpan()
-          span.makeCurrent()
-          contextSpans.add(Context.current())
-          span
-        }
-    val output = block(currentSpan)
-
-    currentSpan.end()
-
-    return output
-  }
-
-  fun event(name: String) {
-    val currentContext = contextSpans.lastOrNull()
-    val currentContextSpan = currentContext?.let { Span.fromContext(it) }
-    currentContextSpan?.addEvent(name)
-  }
-
-  fun setAttribute(key: String, value: String) {
-    val currentContext = contextSpans.lastOrNull()
-    val currentContextSpan = currentContext?.let { Span.fromContext(it) }
-
-    currentContextSpan?.let {
-      Context.current().with(it)
-      it.setAttribute(key, value)
+    } finally {
+      currentSpan.end()
     }
+  }
+
+  suspend fun event(name: String) {
+    currentCoroutineContext().getOpenTelemetryContext().let(Span::fromContext).addEvent(name)
+  }
+
+  suspend fun setAttribute(key: String, value: String) {
+    val span = currentCoroutineContext().getOpenTelemetryContext().let(Span::fromContext)
+
+    Context.current().with(span)
+    span.setAttribute(key, value)
   }
 }


### PR DESCRIPTION
This PR fixes the current problem, where we see Childs being created as child of each other instead of respecting the correct root.

```
- root span
|-- child span 1
  |-- child span 2
    |-- child span 3
```

This issue was caused by using mutation, and picking the last created span as the parent. This implementation suffers from some other issues like race conditions in the face of parallelism.

To fix this we leverage the created coroutines, and we make each Span in its own coroutine and thus all children are created as a child coroutine of the outer parent span. This fixes the hierarchy:

```
- root span
|-- child span 1
|-- child span 2
|-- child span 3
```

As a side effect `event` and `setAttribute` had to become `suspend` since we need to extract the OpenTelemetry `Context` from the `CoroutineContext` but this was non-problematic because all the surrounding code already supports `suspend`.