### PR TITLE
Fix streaming final result

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/StreamedFunction.kt
@@ -112,10 +112,11 @@ sealed class StreamedFunction<out A> {
                 // because the previous chunk may had a partial property whose body
                 // may had not been fully streamed
                 streamProperty(path, currentProperty, functionCall.arguments, streamedProperties)
-
-                // we stream the result
-                streamResult(functionCall, messages, serializer)
               }
+            }
+            if (finishReason != null) {
+              // we stream the result
+              streamResult(functionCall, messages, serializer)
             }
           }
         }


### PR DESCRIPTION
There is currently a bug where if we use `StreamedFunction<A>` we are emitting all properties of `A` but not the final result.