### PR TITLE
Span as client

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
@@ -17,14 +17,16 @@ suspend fun CreateChatCompletionResponse.addMetrics(
 }
 
 suspend fun <T> Prompt<T>.addMetrics(conversation: Conversation) {
+  conversation.metric.parameter("openai.chat_completion.prompt.message.count", "${messages.size}")
+
   conversation.metric.parameter(
-    "openai.chat_completion.prompt.message.count",
-    "${messages.size} (${messages.map { it.completionRole().value.firstOrNull() ?: "" }.joinToString("-")})"
+    "openai.chat_completion.prompt.messages",
+    messages.map { it.completionRole().value }
   )
-  conversation.metric.parameter("openai.chat_completion.conversation.id", conversation.conversationId?.value ?: "none")
+  conversation.metric.parameter("openai.chat_completion.conversation_id", conversation.conversationId?.value ?: "none")
   conversation.metric.parameter(
     "functions",
-    if (functions.isEmpty()) "no" else functions.joinToString(",") { it.name }
+    if (functions.isEmpty()) listOf("no") else functions.map { it.name }
   )
   conversation.metric.parameter("openai.chat_completion.prompt.temperature", "${configuration.temperature}")
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
@@ -10,7 +10,10 @@ suspend fun CreateChatCompletionResponse.addMetrics(
   conversation.metric.parameter("openai.chat_completion.model", model)
   usage?.let {
     conversation.metric.parameter("openai.chat_completion.prompt.token.count", "${it.promptTokens}")
-    conversation.metric.parameter("openai.chat_completion.completion.token.count", "${it.completionTokens}")
+    conversation.metric.parameter(
+      "openai.chat_completion.completion.token.count",
+      "${it.completionTokens}"
+    )
     conversation.metric.parameter("openai.chat_completion.token.count", "${it.totalTokens}")
   }
   return this
@@ -20,13 +23,23 @@ suspend fun <T> Prompt<T>.addMetrics(conversation: Conversation) {
   conversation.metric.parameter("openai.chat_completion.prompt.message.count", "${messages.size}")
 
   conversation.metric.parameter(
-    "openai.chat_completion.prompt.messages",
+    "openai.chat_completion.prompt.messages_roles",
     messages.map { it.completionRole().value }
   )
-  conversation.metric.parameter("openai.chat_completion.conversation_id", conversation.conversationId?.value ?: "none")
   conversation.metric.parameter(
-    "functions",
+    "openai.chat_completion.prompt.last-message",
+    messages.lastOrNull()?.contentAsString() ?: "empty"
+  )
+  conversation.metric.parameter(
+    "openai.chat_completion.conversation_id",
+    conversation.conversationId?.value ?: "none"
+  )
+  conversation.metric.parameter(
+    "openai.chat_completion.functions",
     if (functions.isEmpty()) listOf("no") else functions.map { it.name }
   )
-  conversation.metric.parameter("openai.chat_completion.prompt.temperature", "${configuration.temperature}")
+  conversation.metric.parameter(
+    "openai.chat_completion.prompt.temperature",
+    "${configuration.temperature}"
+  )
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
@@ -8,10 +8,11 @@ suspend fun CreateChatCompletionResponse.addMetrics(
   conversation: Conversation
 ): CreateChatCompletionResponse {
   conversation.metric.parameter("model", model)
-  conversation.metric.parameter(
-    "tokens",
-    "${usage?.promptTokens} (prompt) + ${usage?.completionTokens} (completion) = ${usage?.totalTokens}"
-  )
+  usage?.let {
+    conversation.metric.parameter("tokens.prompt", "${it.promptTokens}")
+    conversation.metric.parameter("tokens.completion", "${it.completionTokens}")
+    conversation.metric.parameter("tokens.total", "${it.totalTokens}")
+  }
   return this
 }
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
@@ -35,11 +35,9 @@ suspend fun <T> Prompt<T>.addMetrics(conversation: Conversation) {
     conversation.conversationId?.value ?: "none"
   )
   conversation.metric.parameter(
-    "openai.chat_completion.functions",
-    if (functions.isEmpty()) listOf("no") else functions.map { it.name }
-  )
-  conversation.metric.parameter(
     "openai.chat_completion.prompt.temperature",
     "${configuration.temperature}"
   )
+  if (functions.isNotEmpty())
+    conversation.metric.parameter("openai.chat_completion.functions", functions.map { it.name })
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
@@ -7,24 +7,24 @@ import com.xebia.functional.xef.prompt.Prompt
 suspend fun CreateChatCompletionResponse.addMetrics(
   conversation: Conversation
 ): CreateChatCompletionResponse {
-  conversation.metric.parameter("model", model)
+  conversation.metric.parameter("openai.chat_completion.model", model)
   usage?.let {
-    conversation.metric.parameter("tokens.prompt", "${it.promptTokens}")
-    conversation.metric.parameter("tokens.completion", "${it.completionTokens}")
-    conversation.metric.parameter("tokens.total", "${it.totalTokens}")
+    conversation.metric.parameter("openai.chat_completion.prompt.token.count", "${it.promptTokens}")
+    conversation.metric.parameter("openai.chat_completion.completion.token.count", "${it.completionTokens}")
+    conversation.metric.parameter("openai.chat_completion.token.count", "${it.totalTokens}")
   }
   return this
 }
 
 suspend fun <T> Prompt<T>.addMetrics(conversation: Conversation) {
   conversation.metric.parameter(
-    "number-of-messages",
+    "openai.chat_completion.prompt.message.count",
     "${messages.size} (${messages.map { it.completionRole().value.firstOrNull() ?: "" }.joinToString("-")})"
   )
-  conversation.metric.parameter("conversation-id", conversation.conversationId?.value ?: "none")
+  conversation.metric.parameter("openai.chat_completion.conversation.id", conversation.conversationId?.value ?: "none")
   conversation.metric.parameter(
     "functions",
     if (functions.isEmpty()) "no" else functions.joinToString(",") { it.name }
   )
-  conversation.metric.parameter("temperature", "${configuration.temperature}")
+  conversation.metric.parameter("openai.chat_completion.prompt.temperature", "${configuration.temperature}")
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/LogsMetric.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/LogsMetric.kt
@@ -46,5 +46,9 @@ class LogsMetric : Metric {
     logger.info { "${writeIndent(numberOfBlocks.get())}|-- $key = $value" }
   }
 
+  override suspend fun parameter(key: String, values: List<String>) {
+    logger.info { "${writeIndent(numberOfBlocks.get())}|-- $key = $values" }
+  }
+
   private fun writeIndent(times: Int = 1) = (1..indentSize * times).fold("") { a, b -> "$a " }
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/Metric.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/Metric.kt
@@ -10,6 +10,7 @@ interface Metric {
   suspend fun event(message: String)
 
   suspend fun parameter(key: String, value: String)
+  suspend fun parameter(key: String, values: List<String>)
 
   companion object {
     val EMPTY: Metric =
@@ -25,6 +26,8 @@ interface Metric {
         override suspend fun event(message: String) {}
 
         override suspend fun parameter(key: String, value: String) {}
+
+        override suspend fun parameter(key: String, values: List<String>) {}
       }
   }
 }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/Metric.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/metrics/Metric.kt
@@ -10,6 +10,7 @@ interface Metric {
   suspend fun event(message: String)
 
   suspend fun parameter(key: String, value: String)
+
   suspend fun parameter(key: String, values: List<String>)
 
   companion object {

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryMetric.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryMetric.kt
@@ -29,6 +29,10 @@ class OpenTelemetryMetric(
     state.setAttribute(key, value)
   }
 
+  override suspend fun parameter(key: String, values: List<String>) {
+    state.setAttribute(key, values)
+  }
+
   private fun getTracer(scopeName: String? = null): Tracer =
     openTelemetry.getTracer(scopeName ?: config.defaultScopeName)
 }

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryMetric.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryMetric.kt
@@ -16,10 +16,7 @@ class OpenTelemetryMetric(
     state.span(name) { block() }
 
   override suspend fun <A, T> promptSpan(prompt: Prompt<T>, block: suspend Metric.() -> A): A =
-    state.span("Prompt: ${prompt.messages.lastOrNull()?.contentAsString() ?: "empty"}") { span ->
-      span.setAttribute("last-message", prompt.messages.lastOrNull()?.contentAsString() ?: "empty")
-      block()
-    }
+    state.span("Prompt: ${prompt.messages.lastOrNull()?.contentAsString() ?: "empty"}") { block() }
 
   override suspend fun event(message: String) {
     state.event(message)

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
@@ -4,7 +4,6 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
 import kotlinx.coroutines.currentCoroutineContext
@@ -32,16 +31,16 @@ class OpenTelemetryState(private val tracer: Tracer) {
   }
 
   suspend fun setAttribute(key: String, value: String) {
-    val span = currentCoroutineContext().getOpenTelemetryContext().let(Span::fromContext)
-
-    Context.current().with(span)
-    span.setAttribute(key, value)
+    currentCoroutineContext()
+      .getOpenTelemetryContext()
+      .let(Span::fromContext)
+      .setAttribute(key, value)
   }
 
   suspend fun setAttribute(key: String, values: List<String>) {
-    val span = currentCoroutineContext().getOpenTelemetryContext().let(Span::fromContext)
-
-    Context.current().with(span)
-    span.setAttribute(AttributeKey.stringArrayKey(key), values)
+    currentCoroutineContext()
+      .getOpenTelemetryContext()
+      .let(Span::fromContext)
+      .setAttribute(AttributeKey.stringArrayKey(key), values)
   }
 }

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
@@ -1,5 +1,6 @@
 package com.xebia.functional.xef.opentelemetry
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -35,5 +36,12 @@ class OpenTelemetryState(private val tracer: Tracer) {
 
     Context.current().with(span)
     span.setAttribute(key, value)
+  }
+
+  suspend fun setAttribute(key: String, values: List<String>) {
+    val span = currentCoroutineContext().getOpenTelemetryContext().let(Span::fromContext)
+
+    Context.current().with(span)
+    span.setAttribute(AttributeKey.stringArrayKey(key), values)
   }
 }

--- a/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
+++ b/integrations/opentelemetry/src/main/kotlin/com/xebia/functional/xef/opentelemetry/OpenTelemetryState.kt
@@ -1,6 +1,7 @@
 package com.xebia.functional.xef.opentelemetry
 
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
@@ -8,12 +9,13 @@ import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 
-class OpenTelemetryState(val tracer: Tracer) {
+class OpenTelemetryState(private val tracer: Tracer) {
 
   suspend fun <A> span(name: String, block: suspend (Span) -> A): A {
     val parentOrRoot = currentCoroutineContext().getOpenTelemetryContext()
 
-    val currentSpan = tracer.spanBuilder(name).setParent(parentOrRoot).startSpan()
+    val currentSpan =
+      tracer.spanBuilder(name).setParent(parentOrRoot).setSpanKind(SpanKind.CLIENT).startSpan()
 
     return try {
       withContext(currentSpan.asContextElement()) {


### PR DESCRIPTION
This pull request introduces changes in how the span's attributes are represented within the OpenTelemetry traces. We have followed some of the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) included on the Opentelemetry website.

The proposed changes are:
- Split the information about the consumed tokens into three different attributes:
  - Prompt
  - Completion
  - Total
- Set the kind of the spans as `client` to represent better what the interactions with OpenAI do. OpenTelemetry documentation says about the client spans:
  > A client span represents a synchronous outgoing remote call such as an outgoing HTTP request or database call.

- Rename some of the span attributes to follow naming conventions
- Add a new function that allows setting an array of strings as the value of a span attribute.
- Group all the attributes under the `openai` namespace