### PR TITLE
Assistants API: Do not attempt to call functions without arguments

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
@@ -134,7 +134,7 @@ class AssistantThread(
         emit(RunDelta.Step(step))
         step.stepDetails.toolCalls().forEach { toolCall ->
           val function = toolCall.function
-          if (function != null) {
+          if (function != null && function.arguments.isNotBlank()) {
             val result: JsonElement = Tool(function.name, function.arguments)
             api.submitToolOuputsToRun(
               threadId = threadId,


### PR DESCRIPTION
Often, the assistant API returns empty arguments for functions that have required arguments.
This check ensures we only attempt to process functions without arguments.