### PR TITLE
Remove the openai-client dependency from the project

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ junit = "5.10.1"
 pdfbox = "3.0.1"
 mysql = "8.0.33"
 semverGradle = "0.5.0-rc.6"
-openai-client-version = "3.6.2"
 jackson = "2.16.1"
 jsonschema = "4.33.1"
 jakarta = "3.0.2"
@@ -99,7 +98,6 @@ lucene-core = { module = "org.apache.lucene:lucene-core", version.ref = "lucene"
 lucene-queries = { module = "org.apache.lucene:lucene-queries", version.ref = "lucene" }
 apache-pdf-box = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
 jdbc-mysql-connector = { module = "mysql:mysql-connector-java", version.ref = "mysql" }
-openai-client = { module = "com.aallam.openai:openai-client", version.ref = "openai-client-version" }
 jackson = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-schema = { module = "com.github.victools:jsonschema-generator", version.ref = "jsonschema" }
 jackson-schema-jakarta = { module = "com.github.victools:jsonschema-module-jakarta-validation", version.ref = "jsonschema" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
     implementation(libs.ktor.server.request.validation)
     implementation(libs.ktor.server.status.pages)
     implementation(libs.logback)
-    implementation(libs.openai.client)
     implementation(libs.suspendApp.core)
     implementation(libs.suspendApp.ktor)
     implementation(libs.uuid)


### PR DESCRIPTION
We are no longer using this dependency in our code:
* `com.aallam.openai:openai-client`

So this pull request removes it from the dependencies section in the `server` project.