### PR TITLE
Upgrade dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 arrow = "1.2.1"
 arrowGradle = "0.12.0-rc.6"
-exposed = "0.45.0"
+exposed = "0.46.0"
 kotlin = "1.9.22"
 kotlinx-json = "1.6.2"
 kotlinx-datetime = "0.5.0"
@@ -35,7 +35,7 @@ suspendApp = "0.4.0"
 flyway = "9.22.3"
 resources-kmp = "0.4.0"
 detekt = "1.23.4"
-opentelemetry="1.33.0"
+opentelemetry="1.34.0"
 opentelemetry-alpha="1.30.1-alpha"
 progressbar = "0.10.0"
 


### PR DESCRIPTION
* Bumps exposed from 0.45.0 to 0.46.0.
* Bumps opentelemetry from 1.33.0 to 1.34.0.