### PR TITLE
Avoiding extra calls in ToolCalls

### DIFF
--- a/examples/src/main/kotlin/com/xebia/functional/xef/assistants/DSL.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/assistants/DSL.kt
@@ -98,7 +98,7 @@ private fun displayStepsStatus(step: AssistantThread.RunDelta.Step) {
             RunStepDetailsToolCallsObjectToolCallsInner.Type.code_interpreter -> "CodeInterpreter"
             RunStepDetailsToolCallsObjectToolCallsInner.Type.retrieval -> "Retrieval"
             RunStepDetailsToolCallsObjectToolCallsInner.Type.function ->
-              "${it.function?.name}(${it.function?.arguments ?: ""}): "
+              "${it.function?.name}(${it.function?.arguments ?: ""}) = ${it.function?.output ?: "empty"}: "
           }
         }
     }


### PR DESCRIPTION
We have detected when we are emitting messages in the stream, we are sending extra calls. That happens when the `status` is `in_progress`  and `type` is `tool_calls`. Sometimes the tools don't have any arguments (maybe OpenAI is preparing the information to send to the tool) and we have to ignore this type of events