### PR TITLE
Fix tool outputs

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Assistant.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Assistant.kt
@@ -56,7 +56,7 @@ class Assistant(
     } catch (e: Exception) {
       val message = "Error calling to tool registered $name: ${e.message}"
       val logger = KtorSimpleLogger("Functions")
-      logger.error(message)
+      logger.error(message, e)
       JsonObject(mapOf("error" to JsonPrimitive(message)))
     }
 

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
@@ -1,5 +1,6 @@
 package com.xebia.functional.xef.llm.assistants
 
+import arrow.fx.coroutines.parMap
 import com.xebia.functional.openai.apis.AssistantsApi
 import com.xebia.functional.openai.infrastructure.ApiClient
 import com.xebia.functional.openai.models.*
@@ -87,7 +88,7 @@ class AssistantThread(
     try {
       var run = checkRun(runId = runId, cache = runCache)
       while (run.status != RunObject.Status.completed) {
-        checkSteps(assistant = assistant, runId = runId, cache = stepCache)
+        checkSteps(run = run, assistant = assistant, runId = runId, cache = stepCache)
         delay(500) // To avoid excessive calls to OpenAI
         checkMessages(cache = messagesCache)
         delay(500) // To avoid excessive calls to OpenAI
@@ -104,10 +105,10 @@ class AssistantThread(
             assistantId = assistant.assistantId,
             status = RunObject.Status.failed,
             lastError =
-              RunObjectLastError(
-                code = RunObjectLastError.Code.server_error,
-                message = e.message ?: "Unknown error"
-              ),
+            RunObjectLastError(
+              code = RunObjectLastError.Code.server_error,
+              message = e.message ?: "Unknown error"
+            ),
             startedAt = null,
             cancelledAt = null,
             failedAt = null,
@@ -159,23 +160,25 @@ class AssistantThread(
   private suspend fun FlowCollector<RunDelta>.checkSteps(
     assistant: Assistant,
     runId: String,
-    cache: MutableSet<RunStepObject>
+    cache: MutableSet<RunStepObject>,
+    run: RunObject
   ) {
     val steps = runSteps(runId)
     steps.forEach { step ->
-      val callsWithArguments =
-        step.stepDetails.toolCalls().filter {
-          it.function != null && it.function!!.arguments.isNotBlank()
-        }
+      val calls =
+        step.stepDetails.toolCalls()
+//          .filter {
+//            it.function != null && it.function!!.arguments.isNotBlank()
+//          }
 
       // We have detected that tool call in in_progress state sometimes don't have any arguments
       // and this is not valid. We need to skip this step in this case.
       val canEmitToolCalls =
         if (
           step.type == RunStepObject.Type.tool_calls &&
-            step.status == RunStepObject.Status.in_progress
+          step.status == RunStepObject.Status.in_progress
         )
-          callsWithArguments.isNotEmpty()
+          calls.isNotEmpty()
         else true
 
       val emitEvent = canEmitToolCalls && step !in cache
@@ -183,31 +186,32 @@ class AssistantThread(
       if (emitEvent) {
         cache.add(step)
         emit(RunDelta.Step(step))
+      }
 
-        if (step.status == RunStepObject.Status.in_progress) {
-          callsWithArguments.forEach { toolCall ->
-            val function = toolCall.function
-            if (function != null && function.arguments.isNotBlank()) {
+      if (run.status == RunObject.Status.requires_action && run.requiredAction?.type == RunObjectRequiredAction.Type.submit_tool_outputs) {
+        val results: Map<String, JsonElement> =
+          calls
+            .filter { it.function != null }.
+            parMap { toolCall ->
+              val function = toolCall.function!!
               val result: JsonElement =
                 assistant.getToolRegistered(function.name, function.arguments)
-              val run = api.submitToolOuputsToRun(
-                threadId = threadId,
-                runId = runId,
-                submitToolOutputsRunRequest =
-                  SubmitToolOutputsRunRequest(
-                    toolOutputs =
-                      listOf(
-                        SubmitToolOutputsRunRequestToolOutputsInner(
-                          toolCallId = toolCall.id,
-                          output = ApiClient.JSON_DEFAULT.encodeToString(result)
-                        )
-                      )
-                  )
+              toolCall.id to result
+            }.toMap()
+        api.submitToolOuputsToRun(
+          threadId = threadId,
+          runId = runId,
+          submitToolOutputsRunRequest =
+          SubmitToolOutputsRunRequest(
+            toolOutputs =
+            results.map { (toolCallId, result) ->
+              SubmitToolOutputsRunRequestToolOutputsInner(
+                toolCallId = toolCallId,
+                output = ApiClient.JSON_DEFAULT.encodeToString(result)
               )
-              emit(RunDelta.Run(run.body()))
             }
-          }
-        }
+          )
+        )
       }
     }
   }

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
@@ -88,7 +88,7 @@ class AssistantThread(
     try {
       var run = checkRun(runId = runId, cache = runCache)
       while (run.status != RunObject.Status.completed) {
-        checkSteps(run = run, assistant = assistant, runId = runId, cache = stepCache)
+        checkSteps(assistant = assistant, runId = runId, cache = stepCache)
         delay(500) // To avoid excessive calls to OpenAI
         checkMessages(cache = messagesCache)
         delay(500) // To avoid excessive calls to OpenAI
@@ -160,8 +160,7 @@ class AssistantThread(
   private suspend fun FlowCollector<RunDelta>.checkSteps(
     assistant: Assistant,
     runId: String,
-    cache: MutableSet<RunStepObject>,
-    run: RunObject
+    cache: MutableSet<RunStepObject>
   ) {
     val steps = runSteps(runId)
     steps.forEach { step ->
@@ -187,7 +186,7 @@ class AssistantThread(
         cache.add(step)
         emit(RunDelta.Step(step))
       }
-
+      val run = getRun(runId)
       if (run.status == RunObject.Status.requires_action && run.requiredAction?.type == RunObjectRequiredAction.Type.submit_tool_outputs) {
         val results: Map<String, JsonElement> =
           calls

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
@@ -190,7 +190,7 @@ class AssistantThread(
             if (function != null && function.arguments.isNotBlank()) {
               val result: JsonElement =
                 assistant.getToolRegistered(function.name, function.arguments)
-              api.submitToolOuputsToRun(
+              val run = api.submitToolOuputsToRun(
                 threadId = threadId,
                 runId = runId,
                 submitToolOutputsRunRequest =
@@ -204,6 +204,7 @@ class AssistantThread(
                       )
                   )
               )
+              emit(RunDelta.Run(run.body()))
             }
           }
         }


### PR DESCRIPTION
Folow the open ai spec:
> When a run has the status: "requires_action" and required_action.type is submit_tool_outputs, this endpoint can be used to submit the outputs from the tool calls once they're all completed. All outputs must be submitted in a single request.

https://platform.openai.com/docs/api-reference/runs/submitToolOutputs