### PR TITLE
Upgrade Gradle version to 8.6

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -127,24 +127,6 @@ kotlin {
               implementation(libs.ktor.client.winhttp)
           }
       }
-      val linuxX64Test by getting
-      val macosX64Test by getting
-      val macosArm64Test by getting
-      val mingwX64Test by getting
-      create("nativeMain") {
-          dependsOn(commonMain)
-          linuxX64Main.dependsOn(this)
-          macosX64Main.dependsOn(this)
-          macosArm64Main.dependsOn(this)
-          mingwX64Main.dependsOn(this)
-      }
-      create("nativeTest") {
-          dependsOn(commonTest)
-          linuxX64Test.dependsOn(this)
-          macosX64Test.dependsOn(this)
-          macosArm64Test.dependsOn(this)
-          mingwX64Test.dependsOn(this)
-      }
     }
 }
 

--- a/filesystem/build.gradle.kts
+++ b/filesystem/build.gradle.kts
@@ -42,15 +42,6 @@ kotlin {
             }
         }
         val jvmTest by getting { dependencies { implementation(libs.kotest.junit5) } }
-        val linuxX64Main by getting
-        val macosX64Main by getting
-        val mingwX64Main by getting
-        create("nativeMain") {
-            dependsOn(commonMain)
-            linuxX64Main.dependsOn(this)
-            macosX64Main.dependsOn(this)
-            mingwX64Main.dependsOn(this)
-        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/openai-client/client/build.gradle.kts
+++ b/openai-client/client/build.gradle.kts
@@ -88,24 +88,6 @@ kotlin {
         val macosX64Main by getting { dependencies { api(libs.ktor.client.cio) } }
         val macosArm64Main by getting { dependencies { api(libs.ktor.client.cio) } }
         val mingwX64Main by getting { dependencies { api(libs.ktor.client.winhttp) } }
-        val linuxX64Test by getting
-        val macosX64Test by getting
-        val macosArm64Test by getting
-        val mingwX64Test by getting
-        create("nativeMain") {
-            dependsOn(commonMain)
-            linuxX64Main.dependsOn(this)
-            macosX64Main.dependsOn(this)
-            macosArm64Main.dependsOn(this)
-            mingwX64Main.dependsOn(this)
-        }
-        create("nativeTest") {
-            dependsOn(commonTest)
-            linuxX64Test.dependsOn(this)
-            macosX64Test.dependsOn(this)
-            macosArm64Test.dependsOn(this)
-            mingwX64Test.dependsOn(this)
-        }
     }
 }
 

--- a/reasoning/build.gradle.kts
+++ b/reasoning/build.gradle.kts
@@ -88,12 +88,6 @@ kotlin {
         val macosX64Main by getting { dependencies { api(libs.ktor.client.cio) } }
         val macosArm64Main by getting { dependencies { api(libs.ktor.client.cio) } }
         val mingwX64Main by getting { dependencies { api(libs.ktor.client.winhttp) } }
-        create("nativeMain") {
-            dependsOn(commonMain)
-            linuxX64Main.dependsOn(this)
-            macosX64Main.dependsOn(this)
-            mingwX64Main.dependsOn(this)
-        }
     }
 }
 

--- a/tokenizer/build.gradle.kts
+++ b/tokenizer/build.gradle.kts
@@ -48,17 +48,6 @@ kotlin {
             nodejs { testTask { useMocha { timeout = "10000" } } }
             browser { testTask { useMocha { timeout = "10000" } } }
         }
-        val linuxX64Main by getting
-        val macosX64Main by getting
-        val macosArm64Main by getting
-        val mingwX64Main by getting
-        create("nativeMain") {
-            dependsOn(commonMain)
-            linuxX64Main.dependsOn(this)
-            macosX64Main.dependsOn(this)
-            macosArm64Main.dependsOn(this)
-            mingwX64Main.dependsOn(this)
-        }
     }
 }
 


### PR DESCRIPTION
This pull request upgrades the Gradle version to `8.6` and gets rid of some warning messages by removing explicit dependencies between source sets because, since Kotlin 1.9.20, the Kotlin Gradle plugin has a built-in default hierarchy template that contains predefined intermediate source sets for some popular use cases. See [Kotlin documentation](https://kotlinlang.org/docs/multiplatform-hierarchy.html#default-hierarchy-template)