### PR TITLE
Attempt to fix build in CI for new OpenAI client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ fun Project.configureBuildAndTestTask(taskName: String, moduleType: ModulePlatfo
           project.exec { commandLine(gradleCommand, "build", *excludedModules) }
         }
         ModulePlatformType.MULTI -> {
-          project.exec { commandLine(gradleCommand, "xef-openai-client:openaiClientGenerate") }
+          project.exec { commandLine(gradleCommand, ":xef-openai-client:openaiClientGenerate") }
           val includedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, true)
           project.exec { commandLine(gradleCommand, *includedModules) }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,7 @@ fun Project.configureBuildAndTestTask(taskName: String, moduleType: ModulePlatfo
       when (moduleType) {
         ModulePlatformType.SINGLE -> {
           val excludedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, false)
-          project.exec { commandLine(gradleCommand, "openaiClientGenerate") }
-          project.exec { commandLine(gradleCommand, "build", *excludedModules) }
+          project.exec { commandLine(gradleCommand, "openaiClientGenerate", "build", *excludedModules) }
         }
         ModulePlatformType.MULTI -> {
           project.exec { commandLine(gradleCommand, "openaiClientGenerate") }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,11 +28,12 @@ fun Project.configureBuildAndTestTask(taskName: String, moduleType: ModulePlatfo
     doLast {
       when (moduleType) {
         ModulePlatformType.SINGLE -> {
+          project.exec { commandLine(gradleCommand, ":xef-openai-client:openaiClientGenerate") }
           val excludedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, false)
-          project.exec { commandLine(gradleCommand, "openaiClientGenerate", "build", *excludedModules) }
+          project.exec { commandLine(gradleCommand, "build", *excludedModules) }
         }
         ModulePlatformType.MULTI -> {
-          project.exec { commandLine(gradleCommand, "openaiClientGenerate") }
+          project.exec { commandLine(gradleCommand, "xef-openai-client:openaiClientGenerate") }
           val includedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, true)
           project.exec { commandLine(gradleCommand, *includedModules) }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+
 plugins {
     base
     alias(libs.plugins.kotlin.multiplatform) apply false
@@ -59,3 +62,9 @@ fun getGradleCommand(platform: String): String {
 
 configureBuildAndTestTask("buildAndTestMultip", ModulePlatformType.MULTI)
 configureBuildAndTestTask("buildAndTestSinglep", ModulePlatformType.SINGLE)
+
+gradle.projectsEvaluated {
+  tasks.withType<KotlinCompile> {
+    dependsOn("openaiClientGenerate")
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,12 +28,12 @@ fun Project.configureBuildAndTestTask(taskName: String, moduleType: ModulePlatfo
     doLast {
       when (moduleType) {
         ModulePlatformType.SINGLE -> {
-          project.exec { commandLine(gradleCommand, ":xef-openai-client:openaiClientGenerate") }
+          project.exec { commandLine(gradleCommand, ":xef-openai-client-generator:openaiClientGenerate") }
           val excludedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, false)
           project.exec { commandLine(gradleCommand, "build", *excludedModules) }
         }
         ModulePlatformType.MULTI -> {
-          project.exec { commandLine(gradleCommand, ":xef-openai-client:openaiClientGenerate") }
+          project.exec { commandLine(gradleCommand, ":xef-openai-client-generator:openaiClientGenerate") }
           val includedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, true)
           project.exec { commandLine(gradleCommand, *includedModules) }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,11 @@ fun Project.configureBuildAndTestTask(taskName: String, moduleType: ModulePlatfo
       when (moduleType) {
         ModulePlatformType.SINGLE -> {
           val excludedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, false)
+          project.exec { commandLine(gradleCommand, "openaiClientGenerate") }
           project.exec { commandLine(gradleCommand, "build", *excludedModules) }
         }
         ModulePlatformType.MULTI -> {
+          project.exec { commandLine(gradleCommand, "openaiClientGenerate") }
           val includedModules = includeOrNotModulesToCommand(multiPlatformModules, platform, true)
           project.exec { commandLine(gradleCommand, *includedModules) }
         }
@@ -63,8 +65,3 @@ fun getGradleCommand(platform: String): String {
 configureBuildAndTestTask("buildAndTestMultip", ModulePlatformType.MULTI)
 configureBuildAndTestTask("buildAndTestSinglep", ModulePlatformType.SINGLE)
 
-gradle.projectsEvaluated {
-  tasks.withType<KotlinCompile> {
-    dependsOn("openaiClientGenerate")
-  }
-}

--- a/openai-client/generator/config/enum_class.mustache
+++ b/openai-client/generator/config/enum_class.mustache
@@ -38,7 +38,7 @@ sealed interface {{classname}} {
     }
 }
 
-private object {{classname}}Serializer : KSerializer<{{classname}}> {
+object {{classname}}Serializer : KSerializer<{{classname}}> {
     private val valueSerializer = {{{dataType}}}.serializer()
     override val descriptor = valueSerializer.descriptor
 

--- a/openai-client/generator/config/model_oneof.mustache
+++ b/openai-client/generator/config/model_oneof.mustache
@@ -17,7 +17,7 @@ sealed interface {{classname}} {
 
 }
 
-private object {{classname}}Serializer : KSerializer<{{classname}}> {
+object {{classname}}Serializer : KSerializer<{{classname}}> {
     @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
     override val descriptor: SerialDescriptor = buildSerialDescriptor("{{classname}}", PolymorphicKind.SEALED) { {{#oneOf}}
       element("{{#lambda.oneOfName}}{{-index}}{{/lambda.oneOfName}}", {{#lambda.serializer}}{{{.}}}{{/lambda.serializer}}.descriptor){{/oneOf}}


### PR DESCRIPTION
 1) ConversationSpec
       memories should have the correct size in the vector store:
     IrLinkageError: Can not get instance of singleton 'ChatCompletionRequestMessageSerializer': No class found for symbol '[ File '/Users/raulraja/workspace/xef/openai-client/client/build/generated/OpenAI/src/commonMain/kotlin/com/xebia/functional/openai/generated/model/CreateChatCompletionRequest.kt' <- com.xebia.functional.openai.generated.model/ChatCompletionRequestMessageSerializer|null[0] ]'
      at throwLinkageError (/Users/raulraja/workspace/xef/core/build/compileSync/js/test/testDevelopmentExecutable/kotlin/js-ir/runtime/unlinked.kt:11:11)
      
JS backend does not like `private object` on Serializers, they have to be public.