### PR TITLE
Recurse if after `tool submission` `run` still requires action.

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
@@ -81,73 +81,95 @@ class AssistantThread(
         when (event) {
           // submit tool outputs and join streams
           is RunDelta.RunRequiresAction -> {
-            val steps =
-              runSteps(event.run.id).map { metric.assistantCreateRunStep(event.run.id) { it } }
-
-            steps.forEach { step ->
-              val calls = step.stepDetails.toolCalls()
-
-              val run = getRun(event.run.id)
-              if (
-                run.status == RunObject.Status.requires_action &&
-                  run.requiredAction?.type == RunObjectRequiredAction.Type.submit_tool_outputs
-              ) {
-                val callsResult: List<Pair<String, Assistant.Companion.ToolOutput>> =
-                  calls
-                    .filterIsInstance<
-                      RunStepDetailsToolCallsObjectToolCallsInner.CaseRunStepDetailsToolCallsFunctionObject
-                    >()
-                    .parMapNotNull { toolCall -> executeToolCall(toolCall, assistant) }
-                val results: Map<String, Assistant.Companion.ToolOutput> = callsResult.toMap()
-                val toolOutputsRequest =
-                  SubmitToolOutputsRunRequest(
-                    toolOutputs =
-                      results.map { (toolCallId, result) ->
-                        SubmitToolOutputsRunRequestToolOutputsInner(
-                          toolCallId = toolCallId,
-                          output =
-                            Json.encodeToString(Assistant.Companion.ToolOutput.serializer(), result)
-                        )
-                      }
-                  )
-                metric.assistantToolOutputsRun(event.run.id) {
-                  api
-                    .submitToolOuputsToRunStream(
-                      threadId = threadId,
-                      runId = event.run.id,
-                      submitToolOutputsRunRequest = toolOutputsRequest,
-                      configure = ::defaultConfig
-                    )
-                    .collect {
-                      val delta = RunDelta.fromServerSentEvent(it)
-                      if (delta is RunDelta.RunStepCompleted) {
-                        emit(delta)
-                        emit(RunDelta.RunSubmitToolOutputs(toolOutputsRequest))
-                      } else {
-                        emit(delta)
-                      }
-                    }
-                  getRun(event.run.id)
-                }
-              }
-            }
+            takeRequiredAction(1, event, this@AssistantThread, assistant, this)
           }
           // previous to submitting tool outputs we let all events pass through the outer flow
-          else -> emit(event)
+          else -> {
+            emit(event)
+          }
         }
       }
   }
 
+  private suspend fun takeRequiredAction(
+    depth: Int,
+    event: RunDelta.RunRequiresAction,
+    assistantThread: AssistantThread,
+    assistant: Assistant,
+    flowCollector: FlowCollector<RunDelta>
+  ) {
+    if (
+      event.run.status == RunObject.Status.requires_action &&
+        event.run.requiredAction?.type == RunObjectRequiredAction.Type.submit_tool_outputs
+    ) {
+      val calls = event.run.requiredAction?.submitToolOutputs?.toolCalls.orEmpty()
+      val callsResult: List<Pair<String, Assistant.Companion.ToolOutput>> =
+        calls.parMapNotNull { toolCall -> assistantThread.executeToolCall(toolCall, assistant) }
+      val results: Map<String, Assistant.Companion.ToolOutput> = callsResult.toMap()
+      val toolOutputsRequest =
+        SubmitToolOutputsRunRequest(
+          toolOutputs =
+            results.map { (toolCallId, result) ->
+              SubmitToolOutputsRunRequestToolOutputsInner(
+                toolCallId = toolCallId,
+                output = Json.encodeToString(Assistant.Companion.ToolOutput.serializer(), result)
+              )
+            }
+        )
+      val run =
+        metric.assistantToolOutputsRun(event.run.id) {
+          api
+            .submitToolOuputsToRunStream(
+              threadId = threadId,
+              runId = event.run.id,
+              submitToolOutputsRunRequest = toolOutputsRequest,
+              configure = ::defaultConfig
+            )
+            .collect {
+              val delta = RunDelta.fromServerSentEvent(it)
+              if (delta is RunDelta.RunStepCompleted) {
+                flowCollector.emit(RunDelta.RunSubmitToolOutputs(toolOutputsRequest))
+              }
+              flowCollector.emit(delta)
+            }
+          val run = getRun(event.run.id)
+          val finalEvent =
+            when (run.status) {
+              RunObject.Status.queued -> RunDelta.RunQueued(run)
+              RunObject.Status.in_progress -> RunDelta.RunInProgress(run)
+              RunObject.Status.requires_action -> RunDelta.RunRequiresAction(run)
+              RunObject.Status.cancelling -> RunDelta.RunCancelling(run)
+              RunObject.Status.cancelled -> RunDelta.RunCancelled(run)
+              RunObject.Status.failed -> RunDelta.RunFailed(run)
+              RunObject.Status.completed -> RunDelta.RunCompleted(run)
+              RunObject.Status.expired -> RunDelta.RunExpired(run)
+            }
+          flowCollector.emit(finalEvent)
+          run
+        }
+
+      if (run.status == RunObject.Status.requires_action) {
+        takeRequiredAction(
+          depth + 1,
+          RunDelta.RunRequiresAction(run),
+          assistantThread,
+          assistant,
+          flowCollector
+        )
+      }
+    }
+  }
+
   private suspend fun executeToolCall(
-    toolCall: RunStepDetailsToolCallsObjectToolCallsInner.CaseRunStepDetailsToolCallsFunctionObject,
+    toolCall: RunToolCallObject,
     assistant: Assistant
   ): Pair<String, Assistant.Companion.ToolOutput>? {
-    val function = toolCall.value.function
+    val function = toolCall.function
     val functionName = function.name
     val functionArguments = function.arguments
     return if (functionName != null && functionArguments != null) {
       val result = assistant.getToolRegistered(functionName, functionArguments)
-      val callId = toolCall.value.id
+      val callId = toolCall.id
       if (callId != null) {
         callId to result
       } else null


### PR DESCRIPTION
This pull request refactors the `AssistantThread` class to handle better scenarios where a run still requires action after tool output submissions. The main changes include introducing a `takeRequiredAction` method that manages tool output submission, and checks run status recursively. This ensures all necessary actions are processed before a run is considered completed.