### PR TITLE
Update README with instruction to build locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ To build the project locally, you can use the following commands:
 ./gradlew openaiClientGenerate
 ./gradlew build
 ```
+
+The server and postgres tests may fail if you don't have [Docker](https://www.docker.com/) installed. 
+The server and postgres related tests depend on [Testcontainers](https://testcontainers.com/), which in turn depends on Docker.
+

--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ In [this](https://xef.ai/learn/quickstart/) small introduction we look at the ma
 ## 🚀 Examples
 
 You can also have a look at the [examples](https://github.com/xebia-functional/xef/tree/main/examples/src/main/kotlin/com/xebia/functional/xef/conversation) to have a feeling of how using the library looks like.
+
+## 🚧 Local Development
+
+To build the project locally, you can use the following commands:
+
+```shell
+./gradlew downloadOpenAIAPI
+./gradlew openaiClientGenerate
+./gradlew build
+```


### PR DESCRIPTION
Added a "Local Development" section to README.md detailing the setup process and dependencies on Docker for running server and Postgres tests using Testcontainers.

**How to Test:**
Verify that the project builds successfully following the new instructions with Docker installed.