### PR TITLE
Enum description in tools

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/functions/JsonSchema.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/functions/JsonSchema.kt
@@ -307,6 +307,7 @@ private fun SerialDescriptor.createJsonSchema(
   }
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 private fun JsonObjectBuilder.applyJsonSchemaDefaults(
   descriptor: SerialDescriptor,
   annotations: List<Annotation>,
@@ -322,25 +323,25 @@ private fun JsonObjectBuilder.applyJsonSchemaDefaults(
     }
   }
 
-  if (descriptor.kind == SerialKind.ENUM) {
-    this["enum"] = descriptor.elementNames
-  }
+  val additionalEnumDescription: String? =
+    if (descriptor.kind == SerialKind.ENUM) {
+      this["enum"] = descriptor.elementNames
+      descriptor.elementNames
+        .mapIndexed { index, name ->
+          "$name (${descriptor.getElementAnnotations(index).lastOfInstance<Description>()?.value})"
+        }
+        .joinToString("\n - ")
+    } else null
 
   if (annotations.isNotEmpty()) {
-    val multiplatformDescription = annotations.filterIsInstance<Description>()
-    val description =
-      if (multiplatformDescription.isEmpty()) {
-        try {
-          val jvmDescription = annotations.filterIsInstance<Description>()
-          jvmDescription.firstOrNull()?.value
-        } catch (e: Throwable) {
-          null
-        }
-      } else {
-        multiplatformDescription.firstOrNull()?.value
-      }
-
-    this["description"] = description
+    val description = annotations.filterIsInstance<Description>().firstOrNull()?.value
+    if (additionalEnumDescription != null) {
+      this["description"] = "$description\n - $additionalEnumDescription"
+    } else {
+      this["description"] = description
+    }
+  } else if (additionalEnumDescription != null) {
+    this["description"] = " - $additionalEnumDescription"
   }
 }
 

--- a/examples/src/main/kotlin/com/xebia/functional/xef/assistants/ToolsWithDescriptions.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/assistants/ToolsWithDescriptions.kt
@@ -1,0 +1,36 @@
+package com.xebia.functional.xef.assistants
+
+import com.xebia.functional.xef.conversation.Description
+import com.xebia.functional.xef.llm.assistants.Assistant
+import com.xebia.functional.xef.llm.assistants.AssistantThread
+import com.xebia.functional.xef.llm.assistants.RunDelta
+import com.xebia.functional.xef.llm.assistants.Tool
+import kotlinx.serialization.Serializable
+
+@Description("Natural numbers")
+enum class NaturalWithDescriptions {
+  @Description("If the number is positive.") POSITIVE,
+  @Description("If the number is negative.") NEGATIVE
+}
+
+@Serializable
+data class SumInputWithDescription(
+  @Description("Left operand") val left: Int,
+  @Description("Right operand") val right: Int,
+  val natural: NaturalWithDescriptions
+)
+
+class SumToolWithDescription : Tool<SumInputWithDescription, Int> {
+  override suspend fun invoke(input: SumInputWithDescription): Int {
+    return input.left + input.right
+  }
+}
+
+suspend fun main() {
+  val toolConfig = Tool.toolOf(SumToolWithDescription()).functionObject
+  println(toolConfig.parameters)
+}
+
+private suspend fun runAssistantAndDisplayResults(thread: AssistantThread, assistant: Assistant) {
+  thread.run(assistant).collect(RunDelta::printEvent)
+}


### PR DESCRIPTION
This PR modifies the serialization info of a tool to allow descriptions in the enum values. So for the following structure: 
```kotlin
@Description("Natural numbers")
enum class NaturalWithDescriptions {
  @Description("If the number is positive.") POSITIVE,
  @Description("If the number is negative.") NEGATIVE
}

@Serializable
data class SumInputWithDescription(
  @Description("Left operand") val left: Int,
  @Description("Right operand") val right: Int,
  val natural: NaturalWithDescriptions
)

class SumToolWithDescription : Tool<SumInputWithDescription, Int> {
  override suspend fun invoke(input: SumInputWithDescription): Int {
    return input.left + input.right
  }
}
```

The serialization will be:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema",
  "type": "object",
  "properties": {
    "left": {
      "type": "number",
      "description": "Left operand"
    },
    "right": {
      "type": "number",
      "description": "Right operand"
    },
    "natural": {
      "type": "string",
      "enum": [
        "POSITIVE",
        "NEGATIVE"
      ],
      "description": "Natural numbers\n - POSITIVE (If the number is positive.)\n - NEGATIVE (If the number is negative.)"
    }
  },
  "required": [
    "left",
    "right",
    "natural"
  ],
  "definitions": {}
}
```