### PR TITLE
Fixed error in enum description

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/functions/JsonSchema.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/models/functions/JsonSchema.kt
@@ -327,15 +327,21 @@ private fun JsonObjectBuilder.applyJsonSchemaDefaults(
     if (descriptor.kind == SerialKind.ENUM) {
       this["enum"] = descriptor.elementNames
       descriptor.elementNames
-        .mapIndexed { index, name ->
-          "$name (${descriptor.getElementAnnotations(index).lastOfInstance<Description>()?.value})"
+        .mapIndexedNotNull { index, name ->
+          val enumDescription =
+            descriptor.getElementAnnotations(index).lastOfInstance<Description>()?.value
+          if (enumDescription != null) {
+            "$name ($enumDescription)"
+          } else {
+            null
+          }
         }
         .joinToString("\n - ")
     } else null
 
   if (annotations.isNotEmpty()) {
     val description = annotations.filterIsInstance<Description>().firstOrNull()?.value
-    if (additionalEnumDescription != null) {
+    if (!additionalEnumDescription.isNullOrEmpty()) {
       this["description"] = "$description\n - $additionalEnumDescription"
     } else {
       this["description"] = description


### PR DESCRIPTION
This PR fixes a case in which, if no description of the enum entries is provided, it will appear as `null`.