### PR TITLE
Fix to ignore tokenizer tests on native for o200k

### DIFF
--- a/tokenizer/src/commonTest/kotlin/com/xebia/functional/tokenizer/O200kBaseTest.kt
+++ b/tokenizer/src/commonTest/kotlin/com/xebia/functional/tokenizer/O200kBaseTest.kt
@@ -6,6 +6,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
 import kotlin.test.Test
 
+// Ignore test on native since not all characters can be encoded
+@IgnoreOnNative
 class O200kBaseTest {
   private val resource = Resource("src/commonTest/resources/o200k_base_encodings.csv")
   private val ENCODING = O200K_BASE.encoding

--- a/tokenizer/src/commonTest/kotlin/com/xebia/functional/tokenizer/predef.kt
+++ b/tokenizer/src/commonTest/kotlin/com/xebia/functional/tokenizer/predef.kt
@@ -53,3 +53,6 @@ fun String.parseEncoding(): List<Int> =
     .split(",")
     .dropLastWhile { it.isEmpty() }
     .map { it.toInt() }
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+expect annotation class IgnoreOnNative()

--- a/tokenizer/src/jsTest/kotlin/com/xebia/functional/tokenizer/predef.kt
+++ b/tokenizer/src/jsTest/kotlin/com/xebia/functional/tokenizer/predef.kt
@@ -1,0 +1,4 @@
+package com.xebia.functional.tokenizer
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+actual annotation class IgnoreOnNative

--- a/tokenizer/src/jvmTest/kotlin/com/xebia/functional/tokenizer/predef.kt
+++ b/tokenizer/src/jvmTest/kotlin/com/xebia/functional/tokenizer/predef.kt
@@ -1,0 +1,4 @@
+package com.xebia.functional.tokenizer
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+actual annotation class IgnoreOnNative

--- a/tokenizer/src/nativeTest/kotlin/com/xebia/functional/tokenizer/predef.kt
+++ b/tokenizer/src/nativeTest/kotlin/com/xebia/functional/tokenizer/predef.kt
@@ -1,0 +1,3 @@
+package com.xebia.functional.tokenizer
+
+actual typealias IgnoreOnNative = kotlin.test.Ignore


### PR DESCRIPTION
This PR makes the o200k tokenizer tests to be ignored on native, since seems that not all characters are able to be encoded, like the ones from Hindi language. This should happen only on native.

The o200k encoding was added here: https://github.com/xebia-functional/xef/pull/748