### PR TITLE
Set default description for assistant tools

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Tool.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Tool.kt
@@ -2,6 +2,7 @@ package com.xebia.functional.xef.llm.assistants
 
 import com.xebia.functional.openai.generated.model.FunctionObject
 import com.xebia.functional.xef.llm.chatFunction
+import com.xebia.functional.xef.llm.defaultFunctionDescription
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
@@ -22,14 +23,16 @@ fun interface Tool<Input, out Output> {
     )
 
     inline fun <reified I, reified O> toolOf(tool: Tool<I, O>): ToolConfig<I, O> {
-      val serializer = serializer<I>()
+      val inputSerializer = serializer<I>()
       val outputSerializer = serializer<O>()
-      val toolSerializer = ToolSerializer(serializer, outputSerializer)
-      val fn = chatFunction(serializer.descriptor)
+      val toolSerializer = ToolSerializer(inputSerializer, outputSerializer)
+      val fn = chatFunction(inputSerializer.descriptor)
+      val fnName = this::class.simpleName ?: error("unnamed class")
+      val fnDescription = defaultFunctionDescription(fnName)
       return ToolConfig(
-        fn.copy(name = tool::class.simpleName ?: error("unnamed class")),
-        toolSerializer,
-        tool
+        functionObject = fn.copy(name = fnName, description = fnDescription),
+        serializers = toolSerializer,
+        tool = tool
       )
     }
   }

--- a/core/src/commonTest/kotlin/com/xebia/functional/xef/assistants/ToolDescriptionTests.kt
+++ b/core/src/commonTest/kotlin/com/xebia/functional/xef/assistants/ToolDescriptionTests.kt
@@ -1,0 +1,29 @@
+package com.xebia.functional.xef.assistants
+
+import com.xebia.functional.xef.functions.FunctionSchemaTests.Request
+import com.xebia.functional.xef.llm.assistants.Tool
+import com.xebia.functional.xef.llm.defaultFunctionDescription
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+
+class ToolDescriptionTests :
+  StringSpec({
+    "Tool has tool name and default description" {
+      val tool = TestTool()
+      val toolConfig = Tool.toolOf(tool)
+      val function = toolConfig.functionObject
+      val fnName = tool::class.simpleName ?: error("unnamed class")
+      function.name shouldBe fnName
+      function.description shouldBe defaultFunctionDescription(fnName)
+    }
+  }) {
+
+  @Serializable data class Request(val input: String)
+
+  @Serializable data class Response(val output: String = "Test response")
+
+  class TestTool : Tool<Request, Response> {
+    override suspend fun invoke(input: Request): Response = Response()
+  }
+}


### PR DESCRIPTION
This PR sets the default description with the correct name when using `toolOf` function.

Other more flexible options, that were contemplated but not will be part of this PR are:

1. Making Tool Serializable: This option would involve marking Tool as serializable using the `@Serializable` and `@Description` annotations. However, I'm uncertain if making Tool serializable adds the necessary value to justify this approach.

2. Passing Description as a Parameter: Another approach could be to modify the `toolOf(tool)` method to accept the `description` as an additional parameter. This method, though functional, is not particularly elegant or intuitive.

3. Target-Specific Implementation: For JVM targets, we could leverage the `@Description` annotation and access it via reflection, and set the description if the parameter is null. For other platforms, we would have to rely only on passing the description as a parameter.

Given that none of these options are completely satisfactory and considering that this feature is not immediately critical, I propose for now just this simple change to set the default description with the correct tool name.