### PR TITLE
Make OpenAI client more configurable

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/AIConfig.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/AIConfig.kt
@@ -8,7 +8,7 @@ import com.xebia.functional.xef.conversation.Conversation
 data class AIConfig(
   val tools: List<Tool<*>> = emptyList(),
   val model: CreateChatCompletionRequestModel = CreateChatCompletionRequestModel.gpt_4o,
-  val config: Config = Config(),
+  val config: Config = Config.Default,
   val openAI: OpenAI = OpenAI(config, logRequests = false),
   val api: Chat = openAI.chat,
   val conversation: Conversation = Conversation()

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/Config.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/Config.kt
@@ -85,6 +85,35 @@ data class HttpClientTimeoutPolicy(
   }
 }
 
+class ConfigBuilder internal constructor(config: Config) {
+  var baseUrl: String = config.baseUrl
+  var httpClientRetryPolicy: HttpClientRetryPolicy = config.httpClientRetryPolicy
+  var httpClientTimeoutPolicy: HttpClientTimeoutPolicy = config.httpClientTimeoutPolicy
+  var apiToken: String? = config.apiToken
+  var organization: String? = config.organization
+  var json: Json = config.json
+  var streamingPrefix: String = config.streamingPrefix
+  var streamingDelimiter: String = config.streamingDelimiter
+
+  fun build(): Config =
+    Config(
+      baseUrl = baseUrl,
+      httpClientRetryPolicy = httpClientRetryPolicy,
+      httpClientTimeoutPolicy = httpClientTimeoutPolicy,
+      apiToken = apiToken,
+      organization = organization,
+      json = json,
+      streamingPrefix = streamingPrefix,
+      streamingDelimiter = streamingDelimiter
+    )
+}
+
+fun Config(from: Config = Config.Default, builderAction: ConfigBuilder.() -> Unit): Config {
+  val builder = ConfigBuilder(from)
+  builder.builderAction()
+  return builder.build()
+}
+
 data class Config(
   val baseUrl: String,
   val httpClientRetryPolicy: HttpClientRetryPolicy,

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/Tool.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/Tool.kt
@@ -128,7 +128,7 @@ sealed class Tool<out A>(
       val typeSerializer = targetClass.serializer()
       val functionObject = chatFunction(typeSerializer.descriptor)
       return Callable(functionObject) {
-        Config.DEFAULT.json.decodeFromString(typeSerializer, it.arguments)
+        Config.Default.json.decodeFromString(typeSerializer, it.arguments)
       }
     }
 
@@ -137,7 +137,7 @@ sealed class Tool<out A>(
       val functionSerializer = Value.serializer(targetClass.serializer())
       val functionObject = chatFunction(functionSerializer.descriptor)
       return Primitive(functionObject) {
-        Config.DEFAULT.json.decodeFromString(functionSerializer, it.arguments).value
+        Config.Default.json.decodeFromString(functionSerializer, it.arguments).value
       }
     }
 
@@ -161,7 +161,7 @@ sealed class Tool<out A>(
         }
       val functionObject = chatFunction(functionSerializer.descriptor)
       return Callable(functionObject) {
-        Config.DEFAULT.json.decodeFromString(functionSerializer, it.arguments).value as A
+        Config.Default.json.decodeFromString(functionSerializer, it.arguments).value as A
       }
     }
 
@@ -205,7 +205,7 @@ sealed class Tool<out A>(
       descriptor: SerialDescriptor
     ): Enumeration<A> {
       val enumSerializer = { value: String ->
-        Config.DEFAULT.json.decodeFromString(targetClass.serializer(), value) as A
+        Config.Default.json.decodeFromString(targetClass.serializer(), value) as A
       }
       val functionObject = chatFunction(descriptor)
       val cases =
@@ -251,7 +251,7 @@ sealed class Tool<out A>(
       sealedClassSerializer: SealedClassSerializer<out Any>
     ): A {
       val newJson = descriptorChoice(it, functionObjectMap)
-      return Config.DEFAULT.json.decodeFromString(
+      return Config.Default.json.decodeFromString(
         sealedClassSerializer,
         Json.encodeToString(newJson)
       ) as A
@@ -263,7 +263,7 @@ sealed class Tool<out A>(
     ): JsonObject {
       // adds a `type` field with the call.functionName serial name equivalent to the call arguments
       val jsonWithDiscriminator =
-        Config.DEFAULT.json.decodeFromString(JsonElement.serializer(), call.arguments)
+        Config.Default.json.decodeFromString(JsonElement.serializer(), call.arguments)
       val descriptor =
         descriptors.values.firstOrNull { it.name.endsWith(call.functionName) }
           ?: error("No descriptor found for ${call.functionName}")

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/ChatWithFunctions.kt
@@ -36,7 +36,7 @@ fun chatFunction(descriptor: SerialDescriptor): FunctionObject {
 @OptIn(ExperimentalSerializationApi::class)
 fun functionSchema(descriptor: SerialDescriptor): JsonObject =
   descriptor.annotations.filterIsInstance<Schema>().firstOrNull()?.value?.let {
-    Config.DEFAULT.json.decodeFromString(JsonObject.serializer(), it)
+    Config.Default.json.decodeFromString(JsonObject.serializer(), it)
   } ?: buildJsonSchema(descriptor)
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Assistant.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Assistant.kt
@@ -20,14 +20,14 @@ import net.mamoe.yamlkt.toYamlElement
 class Assistant(
   val assistantId: String,
   val toolsConfig: List<Tool.Companion.ToolConfig<*, *>> = emptyList(),
-  val config: Config = Config(),
+  val config: Config = Config.Default,
   private val assistantsApi: Assistants = OpenAI(config, logRequests = false).assistants,
 ) {
 
   constructor(
     assistantObject: AssistantObject,
     toolsConfig: List<Tool.Companion.ToolConfig<*, *>> = emptyList(),
-    config: Config = Config(),
+    config: Config = Config.Default,
     assistantsApi: Assistants = OpenAI(config, logRequests = false).assistants,
   ) : this(assistantObject.id, toolsConfig, config, assistantsApi)
 
@@ -85,7 +85,7 @@ class Assistant(
       toolResources: CreateAssistantRequestToolResources? = null,
       metadata: JsonObject? = null,
       toolsConfig: List<Tool.Companion.ToolConfig<*, *>> = emptyList(),
-      config: Config = Config(),
+      config: Config = Config.Default,
       assistantsApi: Assistants = OpenAI(config, logRequests = false).assistants,
     ): Assistant =
       Assistant(
@@ -106,7 +106,7 @@ class Assistant(
     suspend operator fun invoke(
       request: CreateAssistantRequest,
       toolsConfig: List<Tool.Companion.ToolConfig<*, *>> = emptyList(),
-      config: Config = Config(),
+      config: Config = Config.Default,
       assistantsApi: Assistants = OpenAI(config, logRequests = false).assistants,
     ): Assistant {
       val response = assistantsApi.createAssistant(request, configure = ::defaultConfig)
@@ -116,7 +116,7 @@ class Assistant(
     suspend fun fromConfig(
       request: String,
       toolsConfig: List<Tool.Companion.ToolConfig<*, *>> = emptyList(),
-      config: Config = Config(),
+      config: Config = Config.Default,
       assistantsApi: Assistants = OpenAI(config, logRequests = false).assistants,
     ): Assistant {
       val parsed = Yaml.Default.decodeYamlMapFromString(request)

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantThread.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.JsonPrimitive
 class AssistantThread(
   val threadId: String,
   val metric: Metric = Metric.EMPTY,
-  private val config: Config = Config(),
+  private val config: Config = Config.Default,
   private val api: Assistants = OpenAI(config).assistants
 ) {
 
@@ -271,7 +271,7 @@ class AssistantThread(
       messages: List<MessageWithFiles>,
       metadata: JsonObject? = null,
       metric: Metric = Metric.EMPTY,
-      config: Config = Config(),
+      config: Config = Config.Default,
       api: Assistants = OpenAI(config).assistants
     ): AssistantThread =
       AssistantThread(
@@ -303,7 +303,7 @@ class AssistantThread(
       messages: List<String>,
       metadata: JsonObject? = null,
       metric: Metric = Metric.EMPTY,
-      config: Config = Config(),
+      config: Config = Config.Default,
       api: Assistants = OpenAI(config).assistants
     ): AssistantThread =
       AssistantThread(
@@ -333,7 +333,7 @@ class AssistantThread(
       messages: List<CreateMessageRequest> = emptyList(),
       metadata: JsonObject? = null,
       metric: Metric = Metric.EMPTY,
-      config: Config = Config(),
+      config: Config = Config.Default,
       api: Assistants = OpenAI(config).assistants
     ): AssistantThread =
       AssistantThread(
@@ -351,7 +351,7 @@ class AssistantThread(
     suspend operator fun invoke(
       request: CreateThreadRequest,
       metric: Metric = Metric.EMPTY,
-      config: Config = Config(),
+      config: Config = Config.Default,
       api: Assistants = OpenAI(config).assistants
     ): AssistantThread =
       AssistantThread(
@@ -364,7 +364,7 @@ class AssistantThread(
     suspend operator fun invoke(
       request: CreateThreadAndRunRequest,
       metric: Metric = Metric.EMPTY,
-      config: Config = Config(),
+      config: Config = Config.Default,
       api: Assistants = OpenAI(config).assistants
     ): AssistantThread =
       AssistantThread(

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/RunDelta.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/RunDelta.kt
@@ -144,7 +144,7 @@ sealed interface RunDelta {
         RunDeltaEvent.values().find {
           type.replace(".", "").replace("_", "").equals(it.name, ignoreCase = true)
         }
-      val json = Config.DEFAULT.json
+      val json = Config.Default.json
       return when (event) {
         RunDeltaEvent.ThreadCreated ->
           ThreadCreated(json.decodeFromJsonElement(ThreadObject.serializer(), data))

--- a/examples/src/main/kotlin/com/xebia/functional/xef/assistants/AssistantStreaming.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/assistants/AssistantStreaming.kt
@@ -18,7 +18,7 @@ suspend fun main() {
       assistantId = "asst_BwQvmWIbGUMDvCuXOtAFH8B6",
       toolsConfig = listOf(Tool.toolOf(SumTool()))
     )
-  val config = Config.Default.copy(organization = null)
+  val config = Config { organization = null }
   val api = OpenAI(config = config, logRequests = false).assistants
   val thread = AssistantThread(api = api, metric = metric)
   println("Welcome to the Math tutor, ask me anything about math:")

--- a/examples/src/main/kotlin/com/xebia/functional/xef/assistants/AssistantStreaming.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/assistants/AssistantStreaming.kt
@@ -18,7 +18,7 @@ suspend fun main() {
       assistantId = "asst_BwQvmWIbGUMDvCuXOtAFH8B6",
       toolsConfig = listOf(Tool.toolOf(SumTool()))
     )
-  val config = Config(org = null)
+  val config = Config.Default.copy(organization = null)
   val api = OpenAI(config = config, logRequests = false).assistants
   val thread = AssistantThread(api = api, metric = metric)
   println("Welcome to the Math tutor, ask me anything about math:")

--- a/examples/src/main/kotlin/com/xebia/functional/xef/dsl/audio/SimpleSpeech.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/dsl/audio/SimpleSpeech.kt
@@ -14,7 +14,7 @@ import java.io.File
 import javax.media.bean.playerbean.MediaPlayer
 
 suspend fun main() {
-  val config = Config()
+  val config = Config.Default
   val audio = OpenAI(config).audio
   println("ask me something!")
   while (true) {

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/LocalVectorStoreService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/LocalVectorStoreService.kt
@@ -7,5 +7,13 @@ import com.xebia.functional.xef.store.VectorStore
 
 class LocalVectorStoreService : VectorStoreService() {
   override fun getVectorStore(token: String?, org: String?): VectorStore =
-    LocalVectorStore(OpenAI(Config.Default.copy(apiToken = token, organization = org)).embeddings)
+    LocalVectorStore(
+      OpenAI(
+          Config {
+            apiToken = token
+            organization = org
+          }
+        )
+        .embeddings
+    )
 }

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/LocalVectorStoreService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/LocalVectorStoreService.kt
@@ -7,13 +7,5 @@ import com.xebia.functional.xef.store.VectorStore
 
 class LocalVectorStoreService : VectorStoreService() {
   override fun getVectorStore(token: String?, org: String?): VectorStore =
-    LocalVectorStore(
-      OpenAI(
-          Config(
-            token = token,
-            org = org,
-          )
-        )
-        .embeddings
-    )
+    LocalVectorStore(OpenAI(Config.Default.copy(apiToken = token, organization = org)).embeddings)
 }

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresVectorStoreService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresVectorStoreService.kt
@@ -38,7 +38,14 @@ class PostgresVectorStoreService(
   }
 
   override fun getVectorStore(token: String?, org: String?): VectorStore {
-    val embeddingsApi = OpenAI(Config.Default.copy(apiToken = token, organization = org)).embeddings
+    val embeddingsApi =
+      OpenAI(
+          Config {
+            apiToken = token
+            organization = org
+          }
+        )
+        .embeddings
 
     return PGVectorStore(
       vectorSize = vectorSize,

--- a/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresVectorStoreService.kt
+++ b/server/src/main/kotlin/com/xebia/functional/xef/server/services/PostgresVectorStoreService.kt
@@ -38,14 +38,7 @@ class PostgresVectorStoreService(
   }
 
   override fun getVectorStore(token: String?, org: String?): VectorStore {
-    val embeddingsApi =
-      OpenAI(
-          Config(
-            token = token,
-            org = org,
-          )
-        )
-        .embeddings
+    val embeddingsApi = OpenAI(Config.Default.copy(apiToken = token, organization = org)).embeddings
 
     return PGVectorStore(
       vectorSize = vectorSize,


### PR DESCRIPTION
This pull request is the first iteration to improve how Xef instantiates the OpenAI client. The proposed changes are:

- Remove the default values for the properties of the `Config` data class in favor of providing a `Default` instance with such values.
- Implement a `ConfigBuilder` to allow the users to change the default behavior by assigning different values to the properties. For instance:
```
Config {
  organization = "new-organization"
}
```
- Add specific models to configure the timeout and retry policy for the HTTP client more intuitively. For example:
```
Config {
  httpClientRetryPolicy = HttpClientRetryPolicy.Incremental(
          interval = 250.milliseconds,
          maxDelay = 5.seconds,
          maxRetries = 5
        )
}
```