### PR TITLE
Add support for gpt-4o-mini in ModelType

### DIFF
--- a/tokenizer/src/commonMain/kotlin/com/xebia/functional/tokenizer/ModelType.kt
+++ b/tokenizer/src/commonMain/kotlin/com/xebia/functional/tokenizer/ModelType.kt
@@ -43,6 +43,7 @@ sealed class ModelType(
       GPT_4_0613,
       GPT_4_32K_0613_FUNCTIONS,
       GPT_4O,
+      GPT_4O_MINI,
       GPT_4O_2024_05_13,
     )
     val all: List<ModelType> = listOf(
@@ -59,6 +60,7 @@ sealed class ModelType(
       GPT_4_32_K_0314,
       GPT_4_32K_0613_FUNCTIONS,
       GPT_4O,
+      GPT_4O_MINI,
       GPT_4O_2024_05_13,
       GPT_4_TURBO_1106_PREVIEW,
       GPT_4_VISION_PREVIEW,
@@ -148,6 +150,9 @@ sealed class ModelType(
 
   object GPT_4O :
     ModelType("gpt-4o", O200K_BASE, 128000, tokensPerMessage = 3, tokensPerName = 2, tokenPadding = 5)
+
+  object GPT_4O_MINI :
+    ModelType("gpt-4o-mini", O200K_BASE, 128000, tokensPerMessage = 3, tokensPerName = 2, tokenPadding = 5)
 
   object GPT_4O_2024_05_13 :
     ModelType("gpt-4o-2024-05-13", O200K_BASE, 128000, tokensPerMessage = 3, tokensPerName = 2, tokenPadding = 5)


### PR DESCRIPTION
# Background

`ModelType` didn't have the enum of `gpt-4o-mini` with the right encoding configuration, leading to falling back to `ModelType.TODO`, which has `CL100K` encoding. 

This led to errors when using the tokenizer decoder, like in the `AI.runWithEnumSingleTokenSerializer`, which was used for one token enums.

# This PR 

Adds `ModelType.GPT_4O_MINI` with `O200K_BASE` encoding and `128000` context length.

Example:
```kotlin
@Serializable
enum class Sentiment {
  positive,
  negative,
  neutral
}

suspend fun main() {
  val sentiment = AI<Sentiment>("I love Xef!", config = AIConfig(model = CreateChatCompletionRequestModel.gpt_4o_mini))
  println(sentiment) // positive
}
```

which returns `positive`.

