### PR TITLE
Add support for assistant temperature and top_p

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Assistant.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Assistant.kt
@@ -98,6 +98,8 @@ class Assistant(
       tools: List<AssistantObjectToolsInner> = arrayListOf(),
       toolResources: CreateAssistantRequestToolResources? = null,
       metadata: JsonObject? = null,
+      temperature: Double? = null,
+      topP: Double? = null,
       toolsConfig: List<Tool.Companion.ToolConfig<*, *>> = emptyList(),
       config: Config = Config(),
       assistantsApi: Assistants = OpenAI(config, logRequests = false).assistants,
@@ -110,7 +112,9 @@ class Assistant(
           instructions = instructions,
           tools = tools,
           toolResources = toolResources,
-          metadata = metadata
+          metadata = metadata,
+          temperature = temperature,
+          topP = topP
         ),
         toolsConfig,
         config,
@@ -195,6 +199,8 @@ class Assistant(
               }
             },
           toolResources = toolResourcesRequest,
+          temperature = parsed["temperature"]?.literalContentOrNull?.toDoubleOrNull(),
+          topP = parsed["top_p"]?.literalContentOrNull?.toDoubleOrNull(),
         )
       return if (assistantRequest.assistantId != null) {
         val assistant =
@@ -225,7 +231,9 @@ class Assistant(
                     )
                 )
               },
-            metadata = null // assistantRequest.metadata
+            metadata = null, // assistantRequest.metadata
+            temperature = assistantRequest.temperature,
+            topP = assistantRequest.topP
           )
         )
       } else
@@ -241,7 +249,9 @@ class Assistant(
               metadata =
                 assistantRequest.metadata
                   ?.map { (k, v) -> k to JsonPrimitive(v) }
-                  ?.let { JsonObject(it.toMap()) }
+                  ?.let { JsonObject(it.toMap()) },
+              temperature = assistantRequest.temperature,
+              topP = assistantRequest.topP
             ),
           toolsConfig = toolsConfig,
           config = config,

--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantRequest.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/AssistantRequest.kt
@@ -11,22 +11,42 @@ data class AssistantRequest(
   @SerialName(value = "assistant_id") val assistantId: String? = null,
   @SerialName(value = "model") @Required val model: CreateAssistantRequestModel,
 
-  /* The name of the assistant. The maximum length is 256 characters.  */
+  /** The name of the assistant. The maximum length is 256 characters. */
   @SerialName(value = "name") val name: String? = null,
 
-  /* The description of the assistant. The maximum length is 512 characters.  */
+  /** The description of the assistant. The maximum length is 512 characters. */
   @SerialName(value = "description") val description: String? = null,
 
-  /* The system instructions that the assistant uses. The maximum length is 32768 characters.  */
+  /** The system instructions that the assistant uses. The maximum length is 32768 characters. */
   @SerialName(value = "instructions") val instructions: String? = null,
 
-  /* A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `retrieval`, or `function`.  */
+  /**
+   * A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant.
+   * Tools can be of types `code_interpreter`, `retrieval`, or `function`.
+   */
   @SerialName(value = "tools") val tools: List<AssistantTool>? = arrayListOf(),
   @SerialName(value = "tool_resources")
   val toolResources: CreateAssistantRequestToolResources? = null,
 
-  /* Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.  */
-  @SerialName(value = "metadata") val metadata: Map<String, String>? = null
+  /**
+   * Set of 16 key-value pairs that can be attached to an object. This can be useful for storing
+   * additional information about the object in a structured format. Keys can be a maximum of 64
+   * characters long and values can be a maxium of 512 characters long.
+   */
+  @SerialName(value = "metadata") val metadata: Map<String, String>? = null,
+
+  /**
+   * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output
+   * more random, while lower values like 0.2 will make it more focused and deterministic.
+   */
+  @SerialName(value = "temperature") val temperature: Double? = null,
+
+  /**
+   * An alternative to sampling with temperature, called nucleus sampling, where the model considers
+   * the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising
+   * the top 10% probability mass are considered.
+   */
+  @SerialName(value = "top_p") val topP: Double? = null,
 )
 
 @Serializable

--- a/examples/src/main/kotlin/com/xebia/functional/xef/assistants/LoadFromYamlConfig.kt
+++ b/examples/src/main/kotlin/com/xebia/functional/xef/assistants/LoadFromYamlConfig.kt
@@ -1,6 +1,10 @@
 package com.xebia.functional.xef.assistants
 
-import com.xebia.functional.xef.llm.assistants.*
+import com.xebia.functional.xef.llm.assistants.Assistant
+import com.xebia.functional.xef.llm.assistants.AssistantThread
+import com.xebia.functional.xef.llm.assistants.MessageWithFiles
+import com.xebia.functional.xef.llm.assistants.RunDelta
+import com.xebia.functional.xef.llm.assistants.Tool
 
 suspend fun main() {
   //  val filesApi = fromEnvironment(::FilesApi)
@@ -34,6 +38,8 @@ suspend fun main() {
         use_case: "Customer support"
         language: "English"
         additional_info: "This assistant is continuously updated with the latest information."
+      temperature: "0.0"
+      top_p: "1.0"
     """
       .trimIndent()
   val tools = listOf(Tool.toolOf(SumTool()))


### PR DESCRIPTION
# Background

We have updated the OpenAI spec, which introduced `temperature` and `top_p` settings for the Assistants API.

# This PR 

Updates `Assistant` and `AssistantRequest` to support this configuration by passing the class, or reading the assistant YAML.

The `LoadFromYamlConfig` example is updated with both `temperature` and `top_p` set up.
