### PR TITLE
Expose Assistant Tool input and output json config

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Tool.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/Tool.kt
@@ -10,6 +10,12 @@ import kotlinx.serialization.serializer
 fun interface Tool<Input, out Output> {
   suspend operator fun invoke(input: Input): Output
 
+  data class JsonConfig(val inputJson: Json, val outputJson: Json) {
+    companion object {
+      val Default = JsonConfig(inputJson = Json.Default, outputJson = Json.Default)
+    }
+  }
+
   companion object {
 
     data class ToolConfig<Input, out Output>(
@@ -25,15 +31,9 @@ fun interface Tool<Input, out Output> {
 
     data class ToolSerializer(val serializer: KSerializer<*>, val json: Json)
 
-    data class ToolJson(val inputJson: Json, val outputJson: Json) {
-      companion object {
-        val Default = ToolJson(inputJson = Json.Default, outputJson = Json.Default)
-      }
-    }
-
     inline fun <reified I, reified O> toolOf(
       tool: Tool<I, O>,
-      jsonConfig: ToolJson = ToolJson.Default
+      jsonConfig: JsonConfig = JsonConfig.Default
     ): ToolConfig<I, O> {
       val inputSerializer = ToolSerializer(serializer<I>(), jsonConfig.inputJson)
       val outputSerializer = ToolSerializer(serializer<O>(), jsonConfig.outputJson)


### PR DESCRIPTION
# Background
Previously, the configuration for serialization of both the input and output of tools was common. This means both were treated with the same settings, potentially leading to inefficiencies or non-optimal behavior.

# This PR
This PR differentiates the serialization configuration for the tool's input and output JSON. 

E.g. It would allow to set parameters like `explicitNulls = true` for inputs, ensuring that null values are explicitly included, while setting it to `false` for outputs, to potentially omit unnecessary nulls.