### PR TITLE
Add cache policies to CachedTool 

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/CachedTool.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/assistants/CachedTool.kt
@@ -56,8 +56,7 @@ data class CachedToolConfig(
  *
  * Cache is stored in a [Map] of [CachedToolKey] to [CachedToolValue].
  *
- * Supports expiration policies using [CachedToolConfig]. Expiration happens during access to the
- * cache.
+ * Supports expiration policies using [CachedToolConfig].
  */
 abstract class CachedTool<Input, Output>(
   private val cache: Atomic<MutableMap<CachedToolKey<Input>, CachedToolValue<Output>>>,


### PR DESCRIPTION
## Background
The existing implementation of the `CachedTool` abstract class supports caching and some criteria to determine the usage and writing on cache. However, there's no customization on the cache eviction and expiration. by default, there's only write timestamp, and cache eviction happens for the found key only.

## This PR
- Adds two timestamps for `CachedToolValue`, one for access and other for write.
- Adds `CacheExpirationPolicy` to expire by write timestamp or access timestamp. By default it is `WRITE`.
- Adds `CacheEvictionPolicy` to evict only the found key, or to evict all expired entries. By default it is `ALL`.
- Introduces logic adjustments in the `cache` method in order to make work this new features.