### PR TITLE
Handle OpenAI Error server event accordingly

### DIFF
--- a/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
+++ b/core/src/commonMain/kotlin/com/xebia/functional/xef/llm/MetricManagement.kt
@@ -102,6 +102,7 @@ suspend fun RunDelta.addMetrics(metric: Metric): RunDelta {
     is RunDelta.RunStepDelta,
     is RunDelta.RunSubmitToolOutputs,
     is RunDelta.ThreadCreated,
+    is RunDelta.Error,
     is RunDelta.Unknown -> {}
   }
   return this


### PR DESCRIPTION
We are currently handling the `Error` server events coming from OpenAI as `Unknown`, preventing us from getting more accurate information about what went wrong during the interaction with the OpenAI API.

This pull request handles the errors accordingly, decoding the incoming JSON as an `Error` class instance. This change will allow us to respond better to the final user later.